### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ jobs:
       - checkout
       - run: yarn
       - run: yarn test
-      - run: yarn run dist
+      - run: yarn run pack


### PR DESCRIPTION
Integrate with CircleCI, currently only for linting but potentially for building app releases in the future.