### PR TITLE
[WIP] Support for separate login view

### DIFF
--- a/app/renderer/app.js
+++ b/app/renderer/app.js
@@ -1,8 +1,8 @@
 import electron from 'electron';
 import $ from 'jquery';
 import React from 'react';
-import {Route, Redirect, NavLink, Switch} from 'react-router-dom';
-import {history, BrowserRouter as Router, Debug} from 'react-router-util';
+import {Route, NavLink, Switch} from 'react-router-dom';
+import {history, BrowserRouter as Router, Debug, AuthenticatedRoute} from 'react-router-util';
 import 'popper.js/dist/umd/popper';
 import 'bootstrap/util';
 import 'bootstrap/tooltip';
@@ -154,9 +154,7 @@ export default class App extends React.Component {
 					<Debug/>
 
 					<Switch>
-						<Route path="/" exact render={() => (
-							isLoggedIn ? <Redirect to="/dashboard"/> : <Redirect to="/login"/>
-						)}/>
+						<AuthenticatedRoute path="/" exact isAuthenticated={isLoggedIn} redirectTo="/dashboard"/>
 						<Route path="/login" component={Login}/>
 						<Route component={Main}/>
 					</Switch>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"react": "^16.2.0",
 		"react-dom": "^16.2.0",
 		"react-router-dom": "^4.2.2",
-		"react-router-util": "^0.2.0"
+		"react-router-util": "^0.3.0"
 	},
 	"devDependencies": {
 		"babel-core": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4967,9 +4967,9 @@ react-router-dom@^4.2.2:
     react-router "^4.2.0"
     warning "^3.0.0"
 
-react-router-util@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-util/-/react-router-util-0.2.0.tgz#d84cf1d32fe718521f4ef5381ef86c6d0331e2aa"
+react-router-util@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-util/-/react-router-util-0.3.0.tgz#f5fac49e5d64f9f400e2f784f7aff53b1ed06645"
 
 react-router@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
@lukechilds Here's how I imagined it. We would still want your `TabView` component (Or maybe we should just move the `<TabView/>` contents in to `<Main/>`?). Just not all the route nesting.

The only thing that doesn't work is going to `/login` manually when not logged in, but we're not a public website, so it's not something that would happen anyway.

I just opened this to show my approach. Feel free to borrow whatever you want for your PR.