### PR TITLE
Make the login functional

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,7 +7,6 @@ const serve = require('electron-serve');
 const appMenu = require('./menu');
 const config = require('./config');
 const marketmaker = require('./marketmaker');
-const portfolio = require('./portfolio');
 
 require('electron-unhandled')();
 require('electron-debug')({enabled: true, showDevTools: true});
@@ -117,6 +116,6 @@ electron.ipcMain.on('start-marketmaker', async (event, {seedPhrase}) => {
 	mainWindow.send('marketmaker-started', marketmaker.port);
 });
 
-electron.ipcMain.on('get-portfolios', async () => {
-	mainWindow.send('portfolios', await portfolio.getAll());
+electron.ipcMain.on('stop-marketmaker', () => {
+	marketmaker.stop();
 });

--- a/app/portfolio.js
+++ b/app/portfolio.js
@@ -34,9 +34,9 @@ const getAll = async () => {
 	} catch (err) {
 		if (err.code === 'ENOENT') {
 			return [];
-		} else {
-			throw err;
 		}
+
+		throw err;
 	}
 
 	return Promise.all(portfolios.map(async filePath => {

--- a/app/renderer/components/dashboard.js
+++ b/app/renderer/components/dashboard.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import TabView from './tab-view';
+
+/* eslint-disable */
+
+export default class Dashboard extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			mmPortfolio: null,
+		};
+
+		const {portfolio} = this.props;
+		const {api} = portfolio;
+
+		(async () => {
+			this.setState({
+				mmPortfolio: await api.portfolio(),
+			});
+		})();
+	}
+
+	render() {
+		return (
+			<TabView {...this.props}  title="Dashboard">
+					<p>Portfolio: {JSON.stringify(this.state.mmPortfolio, null, '\t')}</p>
+			</TabView>
+		);
+	}
+}

--- a/app/renderer/components/main.js
+++ b/app/renderer/components/main.js
@@ -1,23 +1,18 @@
 import electron from 'electron';
 import $ from 'jquery';
 import React from 'react';
-import {Route, NavLink} from 'react-router-dom';
+import {Route, NavLink, Redirect} from 'react-router-dom';
 import {history} from 'react-router-util';
 import 'popper.js/dist/umd/popper';
 import 'bootstrap/util';
 import 'bootstrap/tooltip';
-import Preferences from './preferences';
 import TabView from './tab-view';
+import Dashboard from './dashboard';
+import Preferences from './preferences';
 
 /* eslint-disable */
 
 // TODO: All these components will be moved into separate files when we actually have something for them. Keeping them here for now for simplicity and to reduce churn.
-
-const Dashboard = props => (
-	<TabView {...props} title="Dashboard">
-			<p>Content</p>
-	</TabView>
-);
 
 const Swap = props => (
 	<TabView {...props} title="Swap">
@@ -81,6 +76,8 @@ export default class Main extends React.Component {
 	render() {
 		return (
 			<div className="Main">
+				<Redirect from="/" to="/dashboard" />
+
 				<div className="with-iconav">
 					<Nav/>
 

--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -1,7 +1,6 @@
 import electron from 'electron';
 import React from 'react';
 import {render} from 'react-dom';
-import Api from './api';
 import App from './app';
 
 require('electron-unhandled')();
@@ -21,36 +20,3 @@ ipc.on('toggle-dark-mode', () => {
 applyDarkMode();
 
 render(<App/>, document.querySelector('#root'));
-
-// TODO: This is only temporary for testing
-// Make sure BarterDEX is running first:
-// docker run -e PASSPHRASE="secure passphrase" -p 127.0.0.1:7783:7783 lukechilds/barterdex-api
-// We call `PASSPHRASE` for `SEED_PHRASE` for clarity of what it actually is
-const SEED_PHRASE = 'secure passphrase';
-
-async function initApi(endpoint) {
-	const api = new Api({
-		endpoint,
-		seedPhrase: SEED_PHRASE,
-	});
-
-	console.log('Portfolio:', await api.portfolio());
-	console.log('Coins:', (await api.coins())[0]);
-}
-
-function initMarketmaker() {
-	const url = config.get('marketmakerUrl');
-	if (url) {
-		console.log('Using custom marketmaker URL:', url);
-		initApi(url);
-		return;
-	}
-
-	electron.ipcRenderer.send('start-marketmaker', {seedPhrase: SEED_PHRASE});
-
-	electron.ipcRenderer.on('marketmaker-started', async (event, port) => {
-		initApi(`http://localhost:${port}`);
-	});
-}
-
-initMarketmaker();

--- a/app/renderer/index.scss
+++ b/app/renderer/index.scss
@@ -13,6 +13,7 @@ body {
 		'Apple Color Emoji',
 		'Segoe UI Emoji',
 		'Segoe UI Symbol';
+	overflow: hidden;
 }
 
 h1,
@@ -91,21 +92,29 @@ hr {
 	.new-portfolio {
 		max-width: 400px;
 		margin: 0 auto;
-		margin-bottom: 80px;
+		margin-bottom: 50px;
 	}
 
 	.portfolios {
 		text-align: center;
 	}
 
+	.portfolio-item-container {
+		display: flex;
+		justify-content: center;
+	}
+
 	.Portfolio {
 		width: 33%;
-		display: inline-block;
 		padding: 1em;
 		text-align: center;
 
 		.PortfolioImage canvas {
 			display: inline-block;
+		}
+
+		.login-form {
+			margin-top: 20px;
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"react": "^16.2.0",
 		"react-blockies": "^1.2.2",
 		"react-dom": "^16.2.0",
+		"react-extras": "^0.1.0",
 		"react-router-dom": "^4.2.2",
 		"react-router-util": "^0.3.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,6 +5074,10 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-extras@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/react-extras/-/react-extras-0.1.0.tgz#741de3dfb361fd900d4a0396a71c5392b51a406e"
+
 react-router-dom@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"


### PR DESCRIPTION
The login is now fully functional \o/ I've even added some info to the dashboard to show that the API communication works. Marketmaker is now only started on login and stopped on logout. I've implemented the `Log Out` button in the HyperDEX menubar menu (Try it out).

I moved all the logic for getting all the portfolios to `<Login/>`, as `<App/>` doesn't need the knowledge. All `<App/>` cares about is the active portfolio. This can also help us prevent leaks between portfolios, although farfetched.

Known issues:

- In the login screen, if you click a portfolio and then click the other one, the first password entry will not hide. I didn't bother implementing this yet until we agree on how we should handle it. I think that's a detail we can handle later. It's not important.
- It's missing a loading indicator when the "Login" button is clicked, as it takes a second to decrypt the password and start marketmaker.

None of the known issues are blockers though, but rather things we can perfect later on when the core functionality is done.