### PR TITLE
Gracefully stop `marketmaker` when logging out

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -56,4 +56,10 @@ export default class Api {
 	ticker() {
 		return this.request({method: 'ticker'});
 	}
+
+	async stop() {
+		try {
+			await this.request({method: 'stop'});
+		} catch (err) {} // Ignoring the error as `marketmaker` doesn't return a response
+	}
 }

--- a/app/renderer/app.js
+++ b/app/renderer/app.js
@@ -22,13 +22,18 @@ export default class App extends React.Component {
 	componentDidMount() {
 		// TODO: The "Log Out" button should be disabled when logged out
 		ipc.on('log-out', () => {
-			ipc.send('stop-marketmaker');
+			this.stopMarketmaker();
 
 			this.setState({
 				isLoggedIn: false,
 				portfolio: null
 			});
 		});
+	}
+
+	async stopMarketmaker() {
+		await this.state.portfolio.api.stop();
+		ipc.send('stop-marketmaker');
 	}
 
 	setPortfolio(portfolio) {


### PR DESCRIPTION
This tells `marketmaker` to stop before killing it, in case it's currently doing something.

