### PR TITLE
Preserve state on renderer reload when in dev

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -119,3 +119,13 @@ electron.ipcMain.on('start-marketmaker', async (event, {seedPhrase}) => {
 electron.ipcMain.on('stop-marketmaker', () => {
 	marketmaker.stop();
 });
+
+// Preserve the state of `<App/>` so we can reload it to the same state
+let appState = '';
+electron.ipcMain.on('set-state', (event, state) => {
+	appState = state;
+	event.returnValue = null;
+});
+electron.ipcMain.on('get-state', event => {
+	event.returnValue = appState;
+});

--- a/app/renderer/app.js
+++ b/app/renderer/app.js
@@ -1,8 +1,10 @@
 import {ipcRenderer as ipc} from 'electron';
+import electronUtil from 'electron-util';
 import React from 'react';
 import {autoBind} from 'react-extras';
 import {Switch} from 'react-router-dom';
 import {BrowserRouter as Router, Debug, AuthenticatedRoute, RouteWithProps} from 'react-router-util';
+import Api from './api';
 import './index.scss';
 import Main from './components/main';
 import Login from './components/login';
@@ -29,13 +31,34 @@ export default class App extends React.Component {
 				portfolio: null
 			});
 		});
+
+		if (electronUtil.is.development) {
+			const state = ipc.sendSync('get-state');
+			if (state) {
+				state.portfolio.api = new Api({
+					endpoint: state.portfolio.api.endpoint,
+					seedPhrase: state.portfolio.api.seedPhrase
+				})
+				this.setState(state);
+			}
+		}
 	}
 
 	setPortfolio(portfolio) {
-		this.setState({
+		const state = {
 			isLoggedIn: true,
 			portfolio
-		});
+		};
+
+		this.setState(state);
+
+		if (electronUtil.is.development) {
+			state.portfolio.api = {
+				endpoint: state.portfolio.api.endpoint,
+				seedPhrase: state.portfolio.api.seedPhrase
+			};
+			ipc.sendSync('set-state', state);
+		}
 	}
 
 	render() {


### PR DESCRIPTION
It's annoying having to login each time you save in the editor and it reloads the renderer. This preserves the state. This also ensures marketmaker is reused, so we don't spawn lots of marketmaker binaries.

Could also save it in localStorage, but not sure we want that because it could persist some old information and cause weird problems.