### PR TITLE
Fix fonts path and clean dist before building

### DIFF
--- a/app/renderer/styles/fonts.scss
+++ b/app/renderer/styles/fonts.scss
@@ -1,4 +1,4 @@
-$SourceSansProFontsPath: '/fonts' !default;
+$SourceSansProFontsPath: '/styles/fonts' !default;
 
 @font-face {
 	font-family: 'Source Sans Pro';

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"babel-loader": "^7.1.2",
 		"babel-preset-react": "^6.24.1",
 		"babel-preset-stage-3": "^6.24.1",
+		"clean-webpack-plugin": "^0.1.17",
 		"copy-webpack-plugin": "^4.2.3",
 		"css-loader": "^0.28.8",
 		"electron": "^1.7.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,14 +3,18 @@ const path = require('path');
 const webpack = require('webpack');
 const NodeEnvPlugin = require('node-env-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 
-const bootstrapPath = path.join(__dirname, 'vendor/bootstrap-dashboard-theme');
-const reactSymbolsPath = path.join(__dirname, 'vendor/reactsymbols-kit');
+const PATHS = {
+	dist: path.join(__dirname, 'app/renderer-dist'),
+	bootstrap: path.join(__dirname, 'vendor/bootstrap-dashboard-theme'),
+	reactSymbols: path.join(__dirname, 'vendor/reactsymbols-kit'),
+};
 
 module.exports = {
 	entry: './app/renderer',
 	output: {
-		path: path.join(__dirname, 'app/renderer-dist'),
+		path: PATHS.dist,
 		filename: 'bundle.js',
 	},
 	target: 'electron',
@@ -21,7 +25,7 @@ module.exports = {
 			'.jsx',
 		],
 		alias: {
-			bootstrap: path.resolve(bootstrapPath, 'js/bootstrap'),
+			bootstrap: path.resolve(PATHS.bootstrap, 'js/bootstrap'),
 		},
 	},
 	module: {
@@ -46,15 +50,15 @@ module.exports = {
 					loader: 'css-loader',
 					options: {
 						alias: {
-							'../fonts': path.join(bootstrapPath, 'fonts'),
+							'../fonts': path.join(PATHS.bootstrap, 'fonts'),
 						},
 					},
 				}, {
 					loader: 'sass-loader',
 					options: {
 						includePaths: [
-							path.join(bootstrapPath, 'scss'),
-							path.join(reactSymbolsPath, 'sass'),
+							path.join(PATHS.bootstrap, 'scss'),
+							path.join(PATHS.reactSymbols, 'sass'),
 						],
 					},
 				}],
@@ -68,6 +72,7 @@ module.exports = {
 	},
 	plugins: [
 		new NodeEnvPlugin(),
+		new CleanWebpackPlugin([PATHS.dist]),
 		new CopyPlugin([
 			{
 				context: 'app/renderer',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,12 @@ classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
+clean-webpack-plugin@^0.1.17:
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.17.tgz#71c57242e6d47204d46f809413176e7bed28ec49"
+  dependencies:
+    rimraf "^2.6.1"
+
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"


### PR DESCRIPTION
Turns out webpack doesn't clean the dist directory before building, so my `renderer-dist` directory had lots of files that were later moved, so I didn't see the issue.