### PR TITLE
Force CircleCI to build on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,11 @@ jobs:
       - run: yarn
       - run: yarn test
       - run: yarn run pack
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/ # Force CircleCI to build on tags


### PR DESCRIPTION
Forgot this initially. We need this for electron-builder to be able to build on new releases.