### PR TITLE
Rate limit requests to marketmaker

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -1,20 +1,23 @@
+import PQueue from 'p-queue';
 import electrumServers from './electrum-servers';
 
 export default class Api {
-	constructor({endpoint, seedPhrase}) {
+	constructor({endpoint, seedPhrase, concurrency = 1}) {
 		if (!(endpoint && seedPhrase)) {
 			throw new Error('The `endpoint` and `seedPhrase` options are required');
 		}
 
 		this.endpoint = endpoint;
 		this.seedPhrase = seedPhrase;
+
+		this.queue = new PQueue({concurrency});
 	}
 
 	async _request(data) {
-		const response = await fetch(this.endpoint, {
+		const response = await this.queue.add(() => fetch(this.endpoint, {
 			method: 'post',
 			body: JSON.stringify(data),
-		});
+		}));
 
 		return response.json();
 	}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"jquery": "^3.2.1",
 		"lodash": "^4.17.4",
+		"p-queue": "^2.3.0",
 		"popper.js": "1.12.6",
 		"react": "^16.2.0",
 		"react-blockies": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4412,6 +4412,10 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
+p-queue@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-2.3.0.tgz#65d55e71bc1500fc413122da98ae457ff8a7c038"
+
 p-tap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-tap/-/p-tap-1.0.0.tgz#dc4fa086135e8688226f6e7dccea67d8322d08df"


### PR DESCRIPTION
Queues all requests to `marketmaker` one at a time 😭

This is a requirement of `marketmaker`, if we make concurrent connections random requests will be dropped resulting in unpredictable errors.

I would suggest we still develop code as if all requests are happening in parallel.

e.g: 

```js
const responses = await Promise.all([
  fetch('request-1'),
  fetch('request-2),
  fetch('request-3'),
]);
```

instead of:

```js
const response1 = await fetch('request-1');
const response2 = await fetch('request-2');
const response3 = await fetch('request-3');
```

Although these are basically identical while we limit requests. As long as we develop as if they're async, if `marketmaker` where to accept multiple connections in the future we could just remove the rate limiting code and the rest of the codebase will work async without changes.