### PR TITLE
Move active view check into view component

### DIFF
--- a/app/renderer/App.js
+++ b/app/renderer/App.js
@@ -55,7 +55,6 @@ class App extends React.Component {
 	}
 
 	render() {
-		const is = view => view === this.state.activeView;
 		const sharedProps = {
 			...this.state,
 			setAppState: this.setAppState,
@@ -65,13 +64,13 @@ class App extends React.Component {
 			<React.Fragment>
 				<div className="window-draggable-area"/>
 
-				<View {...sharedProps} isActive={is('Login')} component={Login}/>
-				<View {...sharedProps} isActive={is('Dashboard')} component={Dashboard}/>
-				<View {...sharedProps} isActive={is('Swap')} component={Swap}/>
-				<View {...sharedProps} isActive={is('Exchange')} component={Exchange}/>
-				<View {...sharedProps} isActive={is('Trades')} component={Trades}/>
-				<View {...sharedProps} isActive={is('Funds')} component={Funds}/>
-				<View {...sharedProps} isActive={is('Preferences')} component={Preferences}/>
+				<View {...sharedProps} component={Login}/>
+				<View {...sharedProps} component={Dashboard}/>
+				<View {...sharedProps} component={Swap}/>
+				<View {...sharedProps} component={Exchange}/>
+				<View {...sharedProps} component={Trades}/>
+				<View {...sharedProps} component={Funds}/>
+				<View {...sharedProps} component={Preferences}/>
 			</React.Fragment>
 		);
 	}

--- a/app/renderer/components/View.js
+++ b/app/renderer/components/View.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
-const View = ({isActive, component: Component, ...rest}) => isActive ? <Component {...rest}/> : null;
+const View = ({isActive, component: Component, ...rest}) => (
+	Component.name === rest.activeView ? <Component {...rest}/> : null
+);
 
 export default View;


### PR DESCRIPTION
Alternative to https://github.com/lukechilds/hyperdex/pull/46

This syntax is super simple but I'm not sure if it's a bit too "magic". It looks like magic but only because the `activeView` prop is passed in via `...sharedProps`.

e.g: This looks magic

```js
<View {...sharedProps} component={Login}/>
<View {...sharedProps} component={Dashboard}/>
```

But it's really just:

```js
<View activeView="Login" component={Login}/>
<View activeView="Login" component={Dashboard}/>
```

What do you think?