### PR TITLE
[WIP] Use global state explicitly

### DIFF
--- a/app/renderer/App.js
+++ b/app/renderer/App.js
@@ -3,6 +3,7 @@ import {is} from 'electron-util';
 import React from 'react';
 import {hot} from 'react-hot-loader';
 import './styles/index.scss';
+import globalState from './global-state';
 import View from './components/View';
 import Login from './views/Login';
 import Dashboard from './views/Dashboard';
@@ -56,25 +57,20 @@ class App extends React.Component {
 
 	render() {
 		const is = view => view === this.state.activeView;
-		const sharedProps = {
-			...this.state,
-			setAppState: this.setAppState,
-		};
-
 		return (
 			<React.Fragment>
 				<div className="window-draggable-area"/>
 
-				<View isActive={is('Login')} component={Login} setAppState={this.setAppState}/>
-				<View isActive={is('Dashboard')} component={Dashboard} {...sharedProps}/>
-				<View isActive={is('Swap')} component={Swap} {...sharedProps}/>
-				<View isActive={is('Exchange')} component={Exchange} {...sharedProps}/>
-				<View isActive={is('Trades')} component={Trades} {...sharedProps}/>
-				<View isActive={is('Funds')} component={Funds} {...sharedProps}/>
-				<View isActive={is('Preferences')} component={Preferences} {...sharedProps}/>
+				<View isActive={is('Login')} component={Login}/>
+				<View isActive={is('Dashboard')} component={Dashboard}/>
+				<View isActive={is('Swap')} component={Swap}/>
+				<View isActive={is('Exchange')} component={Exchange}/>
+				<View isActive={is('Trades')} component={Trades}/>
+				<View isActive={is('Funds')} component={Funds}/>
+				<View isActive={is('Preferences')} component={Preferences}/>
 			</React.Fragment>
 		);
 	}
 }
 
-export default hot(module)(App);
+export default hot(module)(globalState.capture(App));

--- a/app/renderer/global-state.js
+++ b/app/renderer/global-state.js
@@ -1,0 +1,42 @@
+import React from 'react';
+// import hoistNonReactStatic from 'hoist-non-react-statics';
+
+const getDisplayName = Component => Component.displayName || Component.name || 'Component';
+
+const isStatelessComponent = Component => !(typeof Component.prototype !== 'undefined' && typeof Component.prototype.render === 'function');
+
+let _globalState = null;
+let _setState = null;
+
+export default {
+	get() {
+		return _globalState;
+	},
+
+	set(state) {
+		_setState(state);
+	},
+
+	capture(WrappedComponent) {
+		const isStatelessComp = isStatelessComponent(WrappedComponent);
+		const BaseComp = isStatelessComp ? React.Component : WrappedComponent;
+
+		class ReactiveComponent extends BaseComp {
+			constructor(props) {
+				super(props);
+				_globalState = this.state;
+				_setState = this.setState.bind(this);
+			}
+
+			render() {
+				_globalState = this.state;
+				return isStatelessComp ? WrappedComponent(this.props, this.context) : super.render();
+			}
+		}
+
+		// hoistNonReactStatic(ReactiveComponent, WrappedComponent);
+		ReactiveComponent.displayName = `Reactive(${getDisplayName(WrappedComponent)})`;
+
+		return ReactiveComponent;
+	}
+};

--- a/app/renderer/views/Dashboard.js
+++ b/app/renderer/views/Dashboard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import globalState from '../global-state';
 import TabView from './TabView';
 
 const Dashboard = props => (
@@ -7,7 +8,7 @@ const Dashboard = props => (
 			Portfolio:
 		</p>
 		<pre style={{color: '#ccc', overflow: 'scroll', height: '600px'}}>
-			{JSON.stringify(props.currencies, null, '\t')}
+			{JSON.stringify(globalState.get().currencies, null, '\t')}
 		</pre>
 	</TabView>
 );

--- a/app/renderer/views/Funds.js
+++ b/app/renderer/views/Funds.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import globalState from '../global-state';
 import TabView from './TabView';
 
 const Funds = props => {
-	const coins = props.currencies.map(coin => (
+	const coins = globalState.get().currencies.map(coin => (
 		<tr key={coin.coin}>
 			<th>
 				{coin.coin}

--- a/app/renderer/views/Login.js
+++ b/app/renderer/views/Login.js
@@ -1,5 +1,6 @@
 import electron from 'electron';
 import React from 'react';
+import globalState from '../global-state';
 import Api from '../api';
 import CreatePortfolioButton from './CreatePortfolioButton';
 import PortfolioItem from './PortfolioItem';
@@ -56,7 +57,7 @@ export default class Login extends React.Component {
 
 		const {portfolio: currencies} = await api.portfolio();
 
-		this.props.setAppState({
+		globalState.set({
 			activeView: 'Dashboard',
 			portfolio,
 			currencies,

--- a/app/renderer/views/Nav.js
+++ b/app/renderer/views/Nav.js
@@ -1,8 +1,9 @@
 import React from 'react';
+import globalState from '../global-state';
 
 const IconNavItem = props => {
-	const setView = () => props.setAppState({activeView: props.to});
-	const active = props.activeView === props.to;
+	const setView = () => globalState.set({activeView: props.to});
+	const active = globalState.get().activeView === props.to;
 
 	return (
 		<li className="nav-item">

--- a/app/renderer/views/TabView.js
+++ b/app/renderer/views/TabView.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import globalState from '../global-state';
 import Nav from './Nav';
 
 const TabView = props => (
@@ -10,7 +11,7 @@ const TabView = props => (
 				<header className="dashhead">
 					<div className="dashhead-titles">
 						<h6 className="dashhead-subtitle">
-							{props.subtitle || props.portfolio.name}
+							{props.subtitle || globalState.get().portfolio.name}
 						</h6>
 						<h3 className="dashhead-title">
 							{props.title}


### PR DESCRIPTION
I've been working on a React state module and thought I'd try it on Hyperdex.

I love props, but I don't like how we mix props and state. It makes it hard to read the code and know what is state and what is props, especially multiple levels deep (with all the spreading going on). Now that we have all the important state in the app, we could just as easily use it directly instead of passing it around. I find this more readable and explicit.

It's just React `setState()`, but available anywhere. With some proxy magic I can even make `globalState.get().foo` become `globalState.foo`.

I'm curious about your thoughts.

I personally think this makes the code a lot easier to reason about.