### PR TITLE
Add depth chart to the Exchange view

### DIFF
--- a/app/renderer/components/DepthChart.js
+++ b/app/renderer/components/DepthChart.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import {ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip} from 'recharts';
+import roundTo from 'round-to';
+import _ from 'lodash';
+import './DepthChart.scss';
+
+const roundPrice = array => array.map(x => {
+	x.price = roundTo(x.price, 2);
+	return x;
+});
+
+const DepthChart = props => {
+	let {bids, asks, bidDepth, askDepth} = props;
+	const maxDepth = Math.max(bidDepth, askDepth);
+
+	if (!(bids && bids.length > 0)) {
+		bids = [{price: 0, depth: 0}];
+	}
+	if (!(asks && asks.length > 0)) {
+		asks = [{price: 0, depth: 0}];
+	}
+
+	bids = roundPrice(bids);
+	asks = roundPrice(asks);
+	bids = _.sortBy(bids, ['price']);
+	asks = _.sortBy(asks, ['price']);
+
+	return (
+		<div className="DepthChart">
+			<ResponsiveContainer width="50%" minHeight={100}>
+				<AreaChart data={bids}>
+					<Area
+						dataKey="depth"
+						type="linear"
+						stroke="#28af60"
+						fillOpacity={1}
+						fill="#275049"
+						isAnimationActive={false}
+					/>
+					<XAxis
+						dataKey="price"
+						allowDecimals={false}
+						interval="preserveStartEnd"
+						axisLine={{
+							stroke: '#364357',
+							strokeWidth: 2,
+						}}
+						tickLine={{
+							stroke: '#364357',
+						}}
+						tick={{
+							fontSize: '12px',
+							fill: '#7f8fa4',
+						}}
+					/>
+					<YAxis
+						mirror
+						padding={{top: 20}}
+						allowDecimals={false}
+						interval="preserveEnd"
+						scale="linear"
+						domain={['dataMin', maxDepth]}
+						axisLine={{
+							stroke: '#364357',
+							strokeWidth: 2,
+						}}
+						tickLine={{
+							stroke: '#808fa3',
+						}}
+						tick={{
+							fontSize: '12px',
+							fill: '#7f8fa4',
+						}}
+					/>
+					<Tooltip/>
+				</AreaChart>
+			</ResponsiveContainer>
+			<ResponsiveContainer width="50%" minHeight={100} style={{left: '-10px'}}>
+				<AreaChart data={asks}>
+					<Area
+						dataKey="depth"
+						type="linear"
+						stroke="#f80759"
+						fillOpacity={1}
+						fill="#5a2947"
+						isAnimationActive={false}
+					/>
+					<XAxis
+						dataKey="price"
+						allowDecimals={false}
+						interval="preserveStartEnd"
+						axisLine={{
+							stroke: '#364357',
+							strokeWidth: 2,
+						}}
+						tickLine={{
+							stroke: '#364357',
+						}}
+						tick={{
+							fontSize: '12px',
+							fill: '#7f8fa4',
+						}}
+					/>
+					<YAxis
+						mirror
+						padding={{top: 20}}
+						allowDecimals={false}
+						orientation="right"
+						scale="linear"
+						domain={['dataMin', maxDepth]}
+						axisLine={{
+							stroke: '#364357',
+							strokeWidth: 2,
+						}}
+						tickLine={{
+							stroke: '#808fa3',
+						}}
+						tick={{
+							fontSize: '12px',
+							fill: '#7f8fa4',
+						}}
+					/>
+					<Tooltip/>
+				</AreaChart>
+			</ResponsiveContainer>
+		</div>
+	);
+};
+
+export default DepthChart;

--- a/app/renderer/components/DepthChart.scss
+++ b/app/renderer/components/DepthChart.scss
@@ -1,0 +1,25 @@
+/* stylelint-disable selector-class-pattern */
+@import '../styles/variables';
+
+.DepthChart {
+	display: flex;
+
+	/* Hides the first YAxis tick */
+	.recharts-yAxis .recharts-cartesian-axis-tick:first-child {
+		display: none;
+	}
+
+	.recharts-responsive-container:nth-child(1) {
+		.recharts-xAxis .recharts-cartesian-axis-tick:last-child {
+			display: none;
+		}
+	}
+
+	.recharts-responsive-container:nth-child(2) {
+		left: -10px;
+
+		.recharts-xAxis .recharts-cartesian-axis-tick:first-child {
+			display: none;
+		}
+	}
+}

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -15,6 +15,7 @@ class ExchangeContainer extends Container {
 		}
 
 		this.setState({baseCurrency});
+		this.fetchOrderBook();
 	}
 
 	setQuoteCurrency(quoteCurrency) {
@@ -23,10 +24,25 @@ class ExchangeContainer extends Container {
 		}
 
 		this.setState({quoteCurrency});
+		this.fetchOrderBook();
 	}
 
 	setActiveSwapsView(activeSwapsView) {
 		this.setState({activeSwapsView});
+	}
+
+	// TODO: Temp
+	async fetchOrderBook() {
+		if (!window.api) {
+			return;
+		}
+
+		const orderBook = await window.api.orderbook(
+			this.state.baseCurrency,
+			this.state.quoteCurrency,
+		);
+
+		this.setState({orderBook});
 	}
 }
 

--- a/app/renderer/views/Exchange/Buy.js
+++ b/app/renderer/views/Exchange/Buy.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import roundTo from 'round-to';
 import Input from 'components/Input';
 import Button from 'components/Button';
 import Select from 'components/Select';
@@ -62,12 +63,6 @@ const Center = () => {
 			total: 48.1232300,
 		},
 	];
-	function roundTo(val, precision) {
-		const exponent = precision > 0 ? 'e' : 'e-';
-		const exponentNeg = precision > 0 ? 'e-' : 'e';
-		precision = Math.abs(precision);
-		return Number(Math.sign(val) * (Math.round(Math.abs(val) + exponent + precision) + exponentNeg + precision));
-	}
 	// Fake data
 	for (let i = 0; i < 50; i++) {
 		const [row] = data;

--- a/app/renderer/views/Exchange/Chart.js
+++ b/app/renderer/views/Exchange/Chart.js
@@ -1,14 +1,97 @@
 import React from 'react';
 import {exchangeContainer} from 'containers/Exchange';
+import DepthChart from 'components/DepthChart';
 import './Chart.scss';
+
+const bids = [
+	{
+		price: 46.2131,
+		depth: 2000,
+	},
+	{
+		price: 49.34543,
+		depth: 1640,
+	},
+	{
+		price: 52.43534,
+		depth: 1500,
+	},
+	{
+		price: 55.21363218,
+		depth: 1671,
+	},
+	{
+		price: 56.86319039,
+		depth: 398.04,
+	},
+	{
+		price: 59.95965677,
+		depth: 75.48,
+	},
+	{
+		price: 62.34324,
+		depth: 40,
+	},
+];
+
+const asks = [
+	{
+		price: 65.24324,
+		depth: 30,
+	},
+	{
+		price: 69.86319039,
+		depth: 120.14,
+	},
+	{
+		price: 72.95965677,
+		depth: 303,
+	},
+	{
+		price: 75.634523,
+		depth: 800,
+	},
+	{
+		price: 78.324324,
+		depth: 1104,
+	},
+	{
+		price: 81.8657,
+		depth: 902,
+	},
+	{
+		price: 84.6575,
+		depth: 2006,
+	},
+];
 
 const Chart = () => {
 	const {state} = exchangeContainer;
+	const {orderBook} = state;
+
+	if (!orderBook) {
+		exchangeContainer.fetchOrderBook();
+		return null;
+	}
 
 	return (
 		<div className="Exchange--Chart">
 			<div className="chart-container">
 				<h3>{state.baseCurrency}/{state.quoteCurrency} Depth Chart</h3>
+				{/*
+				<DepthChart
+					bids={orderBook.bids}
+					asks={orderBook.asks}
+					bidDepth={orderBook.biddepth}
+					askDepth={orderBook.askdepth}
+				/>
+				*/}
+				<DepthChart
+					bids={bids}
+					asks={asks}
+					bidDepth={2088.75}
+					askDepth={2100.43}
+				/>
 			</div>
 		</div>
 	);

--- a/app/renderer/views/Exchange/Chart.scss
+++ b/app/renderer/views/Exchange/Chart.scss
@@ -3,14 +3,24 @@
 
 .Exchange--Chart {
 	padding: 15px;
+	padding-bottom: 0;
 
 	.chart-container {
 		flex: 1;
-		border: 2px solid var(--section-border-color);
+		position: relative;
+		border-top: 2px solid var(--section-border-color);
 
 		h3 {
 			margin-top: 10px;
 			text-align: center;
+		}
+
+		.DepthChart {
+			position: absolute;
+			top: -6px;
+			left: -6px;
+			right: -14px;
+			bottom: -6px;
 		}
 	}
 }

--- a/app/renderer/views/Exchange/Sell.js
+++ b/app/renderer/views/Exchange/Sell.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import roundTo from 'round-to';
 import Input from 'components/Input';
 import Button from 'components/Button';
 import Select from 'components/Select';
@@ -61,12 +62,6 @@ const Center = () => {
 			total: 48.1232300,
 		},
 	];
-	function roundTo(val, precision) {
-		const exponent = precision > 0 ? 'e' : 'e-';
-		const exponentNeg = precision > 0 ? 'e-' : 'e';
-		precision = Math.abs(precision);
-		return Number(Math.sign(val) * (Math.round(Math.abs(val) + exponent + precision) + exponentNeg + precision));
-	}
 	// Fake data
 	for (let i = 0; i < 50; i++) {
 		const [row] = data;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
 		"react-extras": "^0.5.0",
 		"react-select": "^1.2.1",
 		"read-blob": "^1.1.0",
+		"recharts": "^1.0.0-beta.10",
+		"round-to": "^2.0.0",
 		"sass-extras": "^0.3.0",
 		"unstated": "^1.0.3"
 	},
@@ -60,6 +62,7 @@
 		"xo": "^0.20.0"
 	},
 	"xo": {
+		"nodeVersion": ">=8",
 		"parser": "babel-eslint",
 		"envs": [
 			"node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,6 +1613,10 @@ ccount@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.2.tgz#53b6a2f815bb77b9c2871f7b9a72c3a25f1d8e89"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1744,7 +1748,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.4:
+classnames@2.2.5, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2094,6 +2098,10 @@ core-assert@^0.2.0:
     buf-compare "^1.0.0"
     is-error "^2.2.0"
 
+core-js@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -2301,6 +2309,60 @@ currently-unhandled@^0.4.1:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
+d3-array@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+
+d3-collection@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
+
+d3-color@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
+
+d3-format@1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.2.tgz#1a39c479c8a57fe5051b2e67a3bee27061a74e7a"
+
+d3-interpolate@1, d3-interpolate@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+
+d3-scale@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
 
 dargs@^5.1.0:
   version "5.1.0"
@@ -2550,6 +2612,10 @@ doctrine@^2.0.2, doctrine@^2.1.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0:
   version "0.1.0"
@@ -6877,6 +6943,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -6994,6 +7068,12 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
+raf@^3.2.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 randoma@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/randoma/-/randoma-1.2.0.tgz#a14df5a02b0ddc6bb20ce69358da2f47a768b550"
@@ -7085,6 +7165,12 @@ react-input-autosize@^2.1.2:
   dependencies:
     prop-types "^15.5.8"
 
+react-resize-detector@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-1.1.0.tgz#4a9831fa3caad32230478dd0185cbd2aa91a5ebf"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-select@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
@@ -7092,6 +7178,26 @@ react-select@^1.2.1:
     classnames "^2.2.4"
     prop-types "^15.5.8"
     react-input-autosize "^2.1.2"
+
+react-smooth@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.0.tgz#b29dbebddddb06d21b5b08962167fb9eac1897d8"
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.2.0"
+    react-transition-group "^2.2.1"
+
+react-transition-group@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react@^16.2.0:
   version "16.2.0"
@@ -7233,6 +7339,26 @@ recast@^0.14.4:
     private "~0.1.5"
     source-map "~0.6.1"
 
+recharts-scale@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.3.2.tgz#dac7621714a4765d152cb2adbc30c73b831208c9"
+
+recharts@^1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.0.0-beta.10.tgz#d3cd15df6b7879d5968da3c942b5fcdaf2504fe1"
+  dependencies:
+    classnames "2.2.5"
+    core-js "2.5.1"
+    d3-interpolate "^1.1.5"
+    d3-scale "1.0.6"
+    d3-shape "1.2.0"
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    react-resize-detector "1.1.0"
+    react-smooth "1.0.0"
+    recharts-scale "0.3.2"
+    reduce-css-calc "1.3.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -7253,7 +7379,7 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-reduce-css-calc@^1.2.6:
+reduce-css-calc@1.3.0, reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
   dependencies:
@@ -7585,6 +7711,10 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+round-to@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/round-to/-/round-to-2.0.0.tgz#bcef4f2bcafd9480902c2142150b28c897f03e37"
 
 run-async@^2.0.0, run-async@^2.2.0:
   version "2.3.0"
@@ -9011,6 +9141,12 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
After many failed attempts, I think I finally nailed it. It's made up of two normal area charts.

I've also hooked it up to real data from marketmaker. By default, it's using fake data as there's very little activity on the coins we've enabled. You can try it with real data by uncommenting the commented `DepthChart` tag.

![screen shot 2018-03-19 at 13 21 38](https://user-images.githubusercontent.com/170270/37580932-d76b6e98-2b78-11e8-837c-932d357d333e.png)

Known issue: It's missing middle label. I'll work on that later. It's not essential right now though.