### PR TITLE
Make order form functional

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -113,6 +113,17 @@ export default class Api {
 		});
 	}
 
+	order(opts) {
+		return this.request({
+			method: opts.type,
+			base: opts.baseCurrency,
+			rel: opts.quoteCurrency,
+			basevolume: opts.amount,
+			relvolume: opts.total,
+			price: opts.price,
+		});
+	}
+
 	listUnspent(coin, address) {
 		return this.request({
 			method: 'listunspent',

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -97,15 +97,39 @@ class Bottom extends React.Component {
 		total: 0,
 	};
 
-	handleSubmit = event => {
+	handleSubmit = async event => {
 		event.preventDefault();
 
-		// TODO: Remove this, it's just to test message
-		this.setState({
-			statusMessage: 'Not enough funds. Deposit required.',
+		const {type} = this.props;
+		const {baseCurrency, quoteCurrency} = exchangeContainer.state;
+		const {price, amount, total} = this.state;
+
+		const result = await api.order({
+			type,
+			baseCurrency,
+			quoteCurrency,
+			price,
+			amount,
+			total,
 		});
 
-		// TODO: Handle submit
+		// TODO: If we get this error we should probably show a more helpful error
+		// and grey out the order form for result.wait seconds.
+		// Or alternatively if we know there is a pending trade, prevent them from
+		// placing an order until it's matched.
+		if (result.error) {
+			let statusMessage = result.error;
+			if (result.error === 'only one pending request at a time') {
+				statusMessage = `Only one pending trade at a time, try again in ${result.wait} seconds.`;
+			}
+			return this.setState({statusMessage});
+		}
+
+		this.setState({statusMessage: ''});
+
+		// TODO: Track this in a local DB
+		const trade = result.pending;
+		console.log(trade);
 	};
 
 	handlePriceChange = price => {


### PR DESCRIPTION
This makes the buy and sell order forms functional.

Currently the error handling is pretty naive but I don't think that's important right now. We should probably grey out the order form if there is already a pending trade but we aren't storing the trade history so no way to do that yet.

Also, currently the trade is just logged to the console. It should be pushed into a local DB and kept in sync with mm based on the event stream. However this is gonna take a while to get working reliably so I'll add trade history in a follow up PR.