### PR TITLE
Run Yarn before starting the app in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"start": "webpack && electron app",
 		"dev:watch": "webpack-dev-server --hot",
 		"dev:start": "sleep 1 && electron app",
-		"dev": "(cd app && yarn) & yarn && run-p dev:*",
+		"dev": "yarn && run-p dev:*",
 		"pack": "webpack && electron-builder --dir",
 		"dist": "webpack --mode=production && electron-builder --mac --linux --win",
 		"release": "np --no-publish"


### PR DESCRIPTION
This ensures we always have the correct dependencies. I often switch to a branch and have missing dependencies when starting up. This adds 2 seconds to the dev startup time, but I think it's worth it.

@lukechilds Thoughts?