### PR TITLE
Subscribe to swap progress

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -146,4 +146,12 @@ export default class Api {
 			await this.request({method: 'stop'});
 		} catch (err) {} // Ignoring the error as `marketmaker` doesn't return a response
 	}
+
+	subscribeToSwap(swap) {
+		if (!this.socket) {
+			throw new Error('Swap subscriptions require the socket to be enabled');
+		}
+
+		return this.socket.subscribeToSwap(swap);
+	}
 }

--- a/app/renderer/marketmaker-socket.js
+++ b/app/renderer/marketmaker-socket.js
@@ -30,6 +30,47 @@ class MarketmakerSocket {
 	}
 
 	getResponse = queueId => this._ee.once(`id_${queueId}`);
+
+	// Returns an EventEmitter that will emit events as the status of the swap progresses
+	// Important events:
+	//  - 'progress': All messages related to the swap.
+	//  - 'connected': The swap has been matched.
+	//  - 'update': The atomic swap has advanced a step, the step flag is in the `update` property.
+	//  - 'finished': The atomic swap level has successfully completed.
+	//  - 'failed': The atomic swap has failed, the error code is in the property `error`.
+	//
+	// Any other message with a `method` property will also be emitted via en event of the same name.
+	subscribeToSwap(swap) {
+		const swapEmitter = new Emittery();
+
+		const generateListener = props => message => {
+			const match = Object.entries(props).every(([prop, value]) => message[prop] === value);
+			if (!match) {
+				return;
+			}
+			swapEmitter.emit('progress', message);
+			if (message.method) {
+				swapEmitter.emit(message.method, message);
+			}
+			if (message.method === 'tradestatus' && message.status === 'finished') {
+				swapEmitter.emit('finished', message);
+			}
+		};
+
+		(async () => {
+			const {tradeid, aliceid} = swap;
+			const stopLocalListener = this.on('message', generateListener({tradeid, aliceid}));
+
+			const {requestid, quoteid} = await swapEmitter.once('connected');
+			stopLocalListener();
+			const stopNetworkListener = this.on('message', generateListener({requestid, quoteid}));
+
+			await swapEmitter.once('finished');
+			stopNetworkListener();
+		})();
+
+		return swapEmitter;
+	}
 }
 
 export default MarketmakerSocket;

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -120,7 +120,7 @@ class Bottom extends React.Component {
 		if (result.error) {
 			let statusMessage = result.error;
 			if (result.error === 'only one pending request at a time') {
-				statusMessage = `Only one pending trade at a time, try again in ${result.wait} seconds.`;
+				statusMessage = `Only one pending swap at a time, try again in ${result.wait} seconds.`;
 			}
 			return this.setState({statusMessage});
 		}
@@ -128,8 +128,10 @@ class Bottom extends React.Component {
 		this.setState({statusMessage: ''});
 
 		// TODO: Track this in a local DB
-		const trade = result.pending;
-		console.log(trade);
+		const swap = result.pending;
+		console.log(swap);
+		const ee = api.subscribeToSwap(swap);
+		ee.on('progress', message => console.log('fire!', message));
 	};
 
 	handlePriceChange = price => {


### PR DESCRIPTION
Adds a `subscribeToSwap` method that allows you to pass the pending swap output from an order and will return an event emitter to track the progress of that trade.

Lots of various edge-cases have been accounted for and it conveniently exposes some named events to hook into useful parts of the trade process.

From the comments:

```
// Returns an EventEmitter that will emit events as the status of the swap progresses
// Important events:
//  - 'progress': All messages related to the swap.
//  - 'connected': The swap has been matched.
//  - 'update': The atomic swap level as advanced, the tag is in the `update` property.
//  - 'finished': The atomic swap level has successfully completed.
//  - 'failed': The atomic swap has failed, the error code is in the property `error`.
//
// Any other message with a `method` property will also be emitted via en event of the same name.
```

I think there might be an edge case where an order is placed but never matched. In that case the event listener will be stuck listening for the local ids forever and won't fail. We can probably solve this with more testing and just timing-out a non matched trade and force failing it.

Also, I added the method to the `MarketmakerSocket` class as it seemed to make sense to be there. However it's a pain to call it from there cos you'll need to do `api.socket.subscribeToSwap()` which just looks weird. So I've mapped `api.subscribeToSwap()` to check the socket is enabled and then call `api.socket.subscribeToSwap()`. Not sure if maybe there's a cleaner approach.