### PR TITLE
Add withdraw API method

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -124,7 +124,7 @@ export default class Api {
 		});
 	}
 
-	withdraw(opts) {
+	async withdraw(opts) {
 		if (typeof opts.currency !== 'string') {
 			throw new TypeError(`opts.currency must be a string: ${opts.currency}`);
 		}


### PR DESCRIPTION
You can test with:

```js
_api.withdraw({
	currency: 'KMD',
	address: 'RQm8BNygniNVqVPRYXEosznRZ7uEiooqSm',
	amount: 0.1,
});
```

One thing I've noticed is the Promise never seems to resolve. But the TX definitely gets broadcast, I've verified it on the blockchain.

It could be that James doesn't respond until it's had a network confirmation or something. Or that the `queueId` is missing off the socket response so we never grab the result. I'll raise an issue with James.

But you can hook it up to the withdraw button for now. We just wont get an error on failure until the Promise issue is resolved.