### PR TITLE
Reduce order book state updates

### DIFF
--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -2,6 +2,7 @@
 import _ from 'lodash';
 import appContainer from 'containers/App';
 import fireEvery from '../fire-every';
+import removeOrderBookTimes from '../remove-order-book-times';
 import swapDB from '../swap-db';
 import Container from './Container';
 
@@ -56,7 +57,7 @@ class ExchangeContainer extends Container {
 			this.state.quoteCurrency,
 		);
 
-		if (!_.isEqual(this.state.orderBook, orderBook)) {
+		if (!_.isEqual(removeOrderBookTimes(this.state.orderBook), removeOrderBookTimes(orderBook))) {
 			this.setState({orderBook});
 		}
 	}

--- a/app/renderer/remove-order-book-times.js
+++ b/app/renderer/remove-order-book-times.js
@@ -1,0 +1,14 @@
+import _ from 'lodash';
+
+const removeOrderBookTimes = orderbook => {
+	orderbook = _.cloneDeep(orderbook);
+
+	// These properties change every request and trigger unnecessary re-renders
+	delete orderbook.timestamp;
+	orderbook.bids.forEach(bid => delete bid.age);
+	orderbook.asks.forEach(ask => delete ask.age);
+
+	return orderbook;
+};
+
+export default removeOrderBookTimes;


### PR DESCRIPTION
This was supposed to fix the issue with the depth chart pointer disappearing. However it's still occurring, it seems to be losing focus whenever `appContainer` updates. This happens quite often because when we poll for balances we get a new x/KMD exchange rate for some currencies.

This PR is still useful though, it does stop the order book and depth chart re-rendering every second, and only updates when it actually changes.

Also, to clarify, we don't lose any state information with this PR. The timestamp and ages are only removed for the deep comparison, we store them in state. So we can calculate the current ages based on the timestamp if we need to, although we aren't currently using this information anywhere in the app.