### PR TITLE
Make the debug menu copy swaps

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -6,7 +6,7 @@ const config = require('./config');
 const {openGitHubIssue} = require('./util');
 const {repoUrl, appViews} = require('./constants');
 
-const {app, BrowserWindow, shell} = electron;
+const {app, BrowserWindow, shell, clipboard} = electron;
 const appName = app.getName();
 
 const sendAction = (action, data) => {
@@ -100,10 +100,11 @@ const debugMenu = {
 			},
 		},
 		{
-			label: 'Dump Swap DB',
+			label: 'Copy Swaps',
 			async click() {
 				const [win] = BrowserWindow.getAllWindows();
-				await runJS('_swapDB.getSwaps().then(swaps => console.log(JSON.stringify(swaps)))', win);
+				const swaps = await runJS('_swapDB.getSwaps()', win);
+				clipboard.writeText(JSON.stringify(swaps, null, '\t'));
 			},
 		},
 		{


### PR DESCRIPTION
We're already logging the swaps with the "Log Swaps" menu, so makes sense to just copy it as JSON here instead of forcing the user to first log it and then manually copy-paste the JSON.