### PR TITLE
Improve order input calculations

### DIFF
--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -207,6 +207,13 @@ class Order extends React.Component {
 			price,
 			total: roundTo(price * prevState.amount, 8),
 		}));
+
+		this.setState({price});
+		if (this.state.total > 0) {
+			this.handleTotalChange(this.state.total);
+		} else if (this.state.amount > 0) {
+			this.handleAmountChange(this.state.amount);
+		}
 	}
 
 	handleAmountChange = amount => {


### PR DESCRIPTION
There were two "bugs" with the order input.

Firstly, if you set `total` when there's no `amount`, you get weird NaN warnings in the console. (visually everything looked ok though) Fixed in https://github.com/lukechilds/hyperdex/commit/fe43d92e0c4ec630b020f5786a972503a17eaae5

Secondly, if you didn't set the price first, if you set either `total` **or** `amount`, then set the price, it wouldn't auto-calculate the other. Fixed in https://github.com/lukechilds/hyperdex/commit/5c54d93e4d79872fb76f14bfee0e0a59dbb5b62c

I re-used the `handleTotalChange()` and `handleAmountChange()` functions just so we didn't duplicate calculation logic.

It kinda looks a bit weird to have:

```js
this.handleTotalChange(this.state.total);
```

though.

Thoughts?