### PR TITLE
Make the balance red when it's negative

### DIFF
--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -38,7 +38,7 @@ const Input = ({
 			'Input--disabled': disabled,
 			'Input--readonly': readOnly,
 			'Input--icon': icon,
-			'Input--button': Button,
+			'Input--view': View || Button,
 		},
 		className
 	);

--- a/app/renderer/components/Input.scss
+++ b/app/renderer/components/Input.scss
@@ -73,11 +73,11 @@
 		}
 	}
 
-	--button-width: 38px;
+	--view-width: 38px;
 
-	&--button {
+	&--view {
 		input {
-			padding-right: calc(var(--button-width) + 4px);
+			padding-right: calc(var(--view-width) + 4px);
 		}
 	}
 
@@ -87,7 +87,7 @@
 		top: 0;
 		right: 0;
 		bottom: 0;
-		width: var(--button-width);
+		width: var(--view-width);
 		user-select: none;
 		cursor: default;
 

--- a/app/renderer/views/Dashboard/WithdrawModal.js
+++ b/app/renderer/views/Dashboard/WithdrawModal.js
@@ -58,7 +58,7 @@ class WithdrawModal extends React.Component {
 		const maxAmount = currencyInfo.balance - networkFee;
 		const remainingBalance = roundTo(maxAmount - this.state.amount, 8);
 		const setAmount = amount => {
-			this.setState({amount: Math.min(amount, maxAmount)});
+			this.setState({amount});
 		};
 
 		return (
@@ -125,14 +125,19 @@ class WithdrawModal extends React.Component {
 							</div>
 							<div className="info">
 								<span>Remaining balance:</span>
-								<span>{remainingBalance}</span>
+								<span className={remainingBalance < 0 ? 'negative-balance' : ''}>{remainingBalance}</span>
 							</div>
 						</div>
 						<Button
 							className="withdraw-button"
 							primary
 							value="Withdraw"
-							disabled={!this.state.recepientAddress || !this.state.amount || this.state.isWithdrawing}
+							disabled={
+								!this.state.recepientAddress ||
+								!this.state.amount ||
+								remainingBalance < 0 ||
+								this.state.isWithdrawing
+							}
 							onClick={this.withdrawButtonHandler}
 						/>
 					</React.Fragment>

--- a/app/renderer/views/Dashboard/WithdrawModal.scss
+++ b/app/renderer/views/Dashboard/WithdrawModal.scss
@@ -37,6 +37,10 @@
 		&:first-child {
 			margin-bottom: 20px;
 		}
+
+		.negative-balance {
+			color: var(--red-color);
+		}
 	}
 
 	.withdraw-button {


### PR DESCRIPTION
And disable the Withdraw button, rather than just enforcing the maximum in the inputs, which caused confusion and bad UX.

I don't think we need an error message as it's already obvious from the color change and number why it won't work.

<img width="435" alt="screen shot 2018-04-12 at 16 58 05" src="https://user-images.githubusercontent.com/170270/38670336-b38145b8-3e72-11e8-9e3b-a42a53aa2d1a.png">
