### PR TITLE
Isolate portfolio swap DB instances

### DIFF
--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -6,7 +6,6 @@ import roundTo from 'round-to';
 import {Container} from 'unstated';
 import {appViews} from '../../constants';
 import fireEvery from '../fire-every';
-import swapDB from '../swap-db';
 import {formatCurrency} from '../util';
 
 const config = remote.require('./config');
@@ -38,6 +37,10 @@ class AppContainer extends Container {
 		super();
 		this.views = new Cycled(appViews);
 		this.enabledCoins = config.get('enabledCoins');
+
+		this.getSwapDB = new Promise(resolve => {
+			this.setSwapDB = resolve;
+		});
 	}
 
 	setActiveView(activeView) {
@@ -154,7 +157,6 @@ ipc.on('set-previous-view', () => {
 // TODO: Uncomment this before we do the public release
 /// if (is.development) {
 window._config = electron.remote.require('./config');
-window._swapDB = swapDB;
 /// }
 
 function handleDarkMode() {

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -4,7 +4,6 @@ import {Container} from 'unstated';
 import appContainer from 'containers/App';
 import fireEvery from '../fire-every';
 import removeOrderBookTimes from '../remove-order-book-times';
-import swapDB from '../swap-db';
 
 class ExchangeContainer extends Container {
 	state = {
@@ -23,10 +22,15 @@ class ExchangeContainer extends Container {
 	constructor() {
 		super();
 		this.setSwapHistory();
-		swapDB.on('change', this.setSwapHistory);
+		appContainer.getSwapDB.then(swapDB => {
+			swapDB.on('change', this.setSwapHistory);
+		});
 	}
 
-	setSwapHistory = async () => this.setState({swapHistory: await swapDB.getSwaps()});
+	setSwapHistory = async () => {
+		const swapDB = await appContainer.getSwapDB;
+		this.setState({swapHistory: await swapDB.getSwaps()});
+	};
 
 	setBaseCurrency(baseCurrency) {
 		// Switch if the same as `quoteCurrency`

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -3,6 +3,7 @@ import {setWindowBounds} from 'electron-util';
 import {Container} from 'unstated';
 import {minWindowSize} from '../../constants';
 import Api from '../api';
+import SwapDB from '../swap-db';
 import appContainer from './App';
 import dashboardContainer from './Dashboard';
 
@@ -85,6 +86,9 @@ class LoginContainer extends Container {
 	async handleLogin(portfolioId, password) {
 		const portfolio = this.portfolioFromId(portfolioId);
 
+		const swapDB = new SwapDB(portfolioId);
+		appContainer.setSwapDB(swapDB);
+
 		// TODO: Show some loading here as it takes some time to decrypt the password and then start marketmaker
 		const seedPhrase = await decryptSeedPhrase(portfolio.encryptedSeedPhrase, password);
 		const api = await initApi(seedPhrase);
@@ -95,6 +99,7 @@ class LoginContainer extends Container {
 		// 	// Expose the API for debugging in DevTools
 		// 	// Example: `_api.debug({method: 'portfolio'})`
 		window._api = api;
+		window._swapDB = swapDB;
 		// }
 
 		// TODO: These should be changeable by the user

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -6,8 +6,8 @@ import PQueue from 'p-queue';
 PouchDB.plugin(pouchDBFind);
 
 class SwapDB {
-	constructor() {
-		this.db = new PouchDB('swaps', {adapter: 'idb'});
+	constructor(portfolioId) {
+		this.db = new PouchDB(`swaps-${portfolioId}`, {adapter: 'idb'});
 
 		const ee = new Emittery();
 		this.on = ee.on.bind(ee);
@@ -107,6 +107,4 @@ class SwapDB {
 	}
 }
 
-const swapDB = new SwapDB();
-
-export default swapDB;
+export default SwapDB;

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -9,7 +9,6 @@ import CurrencySelectOption from 'components/CurrencySelectOption';
 import exchangeContainer from 'containers/Exchange';
 import appContainer from 'containers/App';
 import './Order.scss';
-import swapDB from '../../swap-db';
 
 class Top extends React.Component {
 	handleSelectChange = selectedOption => {
@@ -134,6 +133,7 @@ class Bottom extends React.Component {
 
 		const swap = result.pending;
 
+		const swapDB = await appContainer.getSwapDB;
 		swapDB.insertSwap(swap, requestOpts);
 		api.subscribeToSwap(swap.uuid).on('progress', swapDB.updateSwap);
 	};


### PR DESCRIPTION
This gives each portfolio it's own isolated swap DB. So making trades in one portfolio won't show up in your trade history on another portfolio.

This can be refactored to be a bit neater once we have lazy loading containers.

Resolves https://github.com/lukechilds/hyperdex/issues/116