### PR TITLE
Async encryption

### DIFF
--- a/app/encryption.js
+++ b/app/encryption.js
@@ -1,0 +1,11 @@
+'use strict';
+const {createSession} = require('iocane');
+
+const session = createSession()
+	.use('cbc')
+	.setDerivationRounds(300000);
+
+module.exports = {
+	encrypt: session.encrypt.bind(session),
+	decrypt: session.decrypt.bind(session),
+};

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,7 @@
 		"electron-updater": "^2.21.4",
 		"electron-util": "^0.8.0",
 		"get-port": "^3.2.0",
-		"iocane": "^0.10.1",
+		"iocane": "1.0.0-rc2",
 		"load-json-file": "^4.0.0",
 		"make-dir": "^1.2.0",
 		"node-dir": "^0.1.17",

--- a/app/portfolio-util.js
+++ b/app/portfolio-util.js
@@ -1,14 +1,13 @@
 'use strict';
 const path = require('path');
 const {app} = require('electron');
-const iocane = require('iocane');
 const slugify = require('@sindresorhus/slugify');
 const randomString = require('crypto-random-string');
 const writeJsonFile = require('write-json-file');
 const dir = require('node-dir');
 const loadJsonFile = require('load-json-file');
+const {encrypt, decrypt} = require('./encryption');
 
-const {encryptWithPassword: encrypt, decryptWithPassword: decrypt} = iocane.crypto;
 const portfolioPath = path.join(app.getPath('userData'), 'portfolios');
 
 const idToFileName = id => `hyperdex-portfolio-${id}.json`;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -155,7 +155,7 @@ debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0, debug@~3.1.0:
+debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -344,10 +344,6 @@ hash-base@^2.0.0:
   dependencies:
     inherits "^2.0.1"
 
-hash_file@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/hash_file/-/hash_file-0.1.1.tgz#3210e85dfb4ed6eb640351e02a48b0d0db327878"
-
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -356,12 +352,10 @@ inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-iocane@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/iocane/-/iocane-0.10.1.tgz#d0265e702ea18cbc36b3ac509276349257623430"
+iocane@1.0.0-rc2:
+  version "1.0.0-rc2"
+  resolved "https://registry.yarnpkg.com/iocane/-/iocane-1.0.0-rc2.tgz#04ece911c631e648be4a76baa916a11e3d1d91b1"
   dependencies:
-    debug "~3.1.0"
-    hash_file "~0.1.1"
     pbkdf2 "~3.0.4"
 
 irregular-plurals@^1.0.0:


### PR DESCRIPTION
Resolves #92

This stops portfolio encryption/decryption blocking the main thread.

I've also extracted the encryption logic into a separate module that just exports `encrypt()` and `decrypt()` functions. This should make it easier to maintain and possibly refactor in the future.

This currently uses `iocane@1.0.0-rc2`. I think that's fine for now, it's unlikely there will be any breaking changes before the official v1 release.