### PR TITLE
Add `getFee(coin)` API method

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -126,11 +126,17 @@ export default class Api {
 		});
 	}
 
-	getFee(coin) {
-		return this.request({
+	async getFee(coin) {
+		const response = await this.request({
 			method: 'getfee',
 			coin,
 		});
+
+		if (response.result !== 'success') {
+			throw new Error(`Encountered an error:\n${util.format(response)}`);
+		}
+
+		return response.txfee;
 	}
 
 	async withdraw(opts) {


### PR DESCRIPTION
Perquisite for https://github.com/lukechilds/hyperdex/issues/104

```js
await api.getFee('BTC');
// {result: "success", coin: "BTC", txfee: 0.0002}

await api.getFee('KMD');
// {result: "success", coin: "KMD", txfee: 0.00001}
```