### PR TITLE
Fix "Failed to fetch" error when logging out

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -185,9 +185,12 @@ export default class Api {
 	}
 
 	async stop() {
+		this.queue.pause();
+		this.queue.clear();
+
 		try {
 			await this.request({method: 'stop'});
-		} catch (err) {} // Ignoring the error as `marketmaker` doesn't return a response
+		} catch (_) {} // Ignoring the error as `marketmaker` doesn't return a response
 	}
 
 	subscribeToSwap(swap) {


### PR DESCRIPTION
This was caused by us continuing to add new fetch requests to the queue even after stopping marketmaker.