### PR TITLE
Support cancel order api

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -126,6 +126,19 @@ export default class Api {
 		});
 	}
 
+	async cancelOrder(uuid) {
+		const response = await this.request({
+			method: 'cancel',
+			uuid,
+		});
+
+		if (response.result !== 'success') {
+			throw new Error(`Encountered an error:\n${util.format(response)}`);
+		}
+
+		return response.status;
+	}
+
 	async getFee(coin) {
 		const response = await this.request({
 			method: 'getfee',


### PR DESCRIPTION
Prerequisite for https://github.com/lukechilds/hyperdex/issues/144

Currently only pending swaps can be cancelled, if you try to cancel a matched/failed/nonexistent swap you'll get an error.

```js
await api.cancelOrder(uuid);
// 'uuid canceled'

await api.cancelOrder(uuidThatcantBeCancelled);
// Error: Encountered an error:
// { error: 'uuid not cancellable' }
```

Support for this was added in BarterDEX Marketmaker v1.0.145 (https://github.com/lukechilds/hyperdex/commit/52e5adc5553c92d0d2296ecf7aeb087a5faae8a0)