### PR TITLE
Change debug menu to log swap data not formatted swaps

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -93,10 +93,10 @@ const createDebugMenu = () => {
 				},
 			},
 			{
-				label: 'Copy Swaps',
+				label: 'Copy Swap Data',
 				async click() {
 					const [win] = BrowserWindow.getAllWindows();
-					const swaps = await runJS('_swapDB.getSwaps()', win);
+					const swaps = await runJS('_swapDB._getAllSwapData()', win);
 					clipboard.writeText(JSON.stringify(swaps, null, '\t'));
 				},
 			},


### PR DESCRIPTION
If testers are using this to report issues to us, it will be more helpful we get the raw DB data, not the formatted data which drops a lot of the message data.