### PR TITLE
Remove old swap compatibility

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -64,12 +64,6 @@ class SwapDB {
 	_formatSwap(data) {
 		const {uuid, timeStarted, response, messages} = data;
 
-		// Just to supress errors from the old swap schema
-		// This should be removed
-		if (!response) {
-			return {uuid: Math.random()};
-		}
-
 		const swap = {
 			uuid,
 			timeStarted,


### PR DESCRIPTION
I just added this in so we could test the functionality without clearing our DBs. Without it the old format would be completely wrong and you'd get loads of undefined errors and React key errors.

If you're on a fresh database you should never encounter this so this code is redundant.