### PR TITLE
Switch to a better API for the currency price graphs

### DIFF
--- a/app/renderer/components/TimeSeriesChart.js
+++ b/app/renderer/components/TimeSeriesChart.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {ResponsiveContainer, AreaChart, Area, XAxis, Tooltip} from 'recharts';
+import {ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip} from 'recharts';
 import {format as formatDate} from 'date-fns';
 import {formatCurrency} from '../util';
 import './TimeSeriesChart.scss';
@@ -24,13 +24,16 @@ const resolutionToLabelFormat = new Map([
 	['all', 'MMMM YYYY'],
 ]);
 
-const TimeSeriesChart = props => {
-	const labelFormat = resolutionToLabelFormat.get(props.resolution);
+const TimeSeriesChart = ({
+	data,
+	resolution,
+}) => {
+	const labelFormat = resolutionToLabelFormat.get(resolution);
 
 	return (
 		<div className="TimeSeriesChart">
 			<ResponsiveContainer width="100%" minHeight={100}>
-				<AreaChart data={props.data}>
+				<AreaChart data={data}>
 					<Area
 						dataKey="value"
 						name="Value"
@@ -56,6 +59,11 @@ const TimeSeriesChart = props => {
 							fontSize: '12px',
 							fill: '#687bf7',
 						}}
+					/>
+					<YAxis
+						domain={['auto', 'auto']}
+						padding={{top: 5}}
+						hide
 					/>
 					<Tooltip content={<CustomTooltip/>} isAnimationActive={false} animationDuration={0}/>
 				</AreaChart>

--- a/app/renderer/containers/Login.js
+++ b/app/renderer/containers/Login.js
@@ -104,7 +104,7 @@ class LoginContainer extends Container {
 
 		await appContainer.watchCMC();
 		await appContainer.watchCurrencies();
-		await dashboardContainer.watchCoinCap();
+		await dashboardContainer.watchCurrencyHistory();
 
 		config.set('lastActivePortfolioId', portfolio.id);
 

--- a/app/renderer/views/Dashboard/Chart.js
+++ b/app/renderer/views/Dashboard/Chart.js
@@ -45,9 +45,7 @@ const Chart = () => {
 			<div className="overlay">
 				<h3>{dashboardContainer.activeCurrency.symbol} Chart</h3>
 				<div className="resolution-buttons">
-					{/* Disabled because of https://github.com/CoinCapDev/CoinCap.io/issues/120
-						<ResolutionButton title="1h" resolution="hour"/>
-					*/}
+					<ResolutionButton title="1h" resolution="hour"/>
 					<ResolutionButton title="1d" resolution="day"/>
 					<ResolutionButton title="1w" resolution="week"/>
 					<ResolutionButton title="1m" resolution="month"/>


### PR DESCRIPTION
This changes the API to https://min-api.cryptocompare.com, resulting in improved performance, better resolution on the graphs, and fixes the number bugs with the previous API. This also adds a `1 Hour` resolution, as we now have the data for that too. And it now gracefully handles the API being down/unavailable.