### PR TITLE
Horizontally center price 24h% change

### DIFF
--- a/app/renderer/views/Dashboard/Wallet.scss
+++ b/app/renderer/views/Dashboard/Wallet.scss
@@ -26,7 +26,8 @@
 
 			.price-change {
 				position: absolute;
-				left: 2px;
+				left: 50%;
+				transform: translateX(-50%);
 				bottom: -20px;
 				font-size: 12px;
 				font-weight: 400;


### PR DESCRIPTION
There might be a better new flexbox/grid way to do this but this is how I'd normally do it.

Previously:
![screen shot 2018-04-28 at 5 35 04 pm](https://user-images.githubusercontent.com/2123375/39395658-3aef35f6-4b0b-11e8-9db3-fa14bac33b0d.png)

Now:
![screen shot 2018-04-28 at 5 36 28 pm](https://user-images.githubusercontent.com/2123375/39395662-41511a04-4b0b-11e8-9cff-35fabd4a028e.png)
