### PR TITLE
Fix problem with code signing the macOS app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -13,7 +13,7 @@
 	"dependencies": {
 		"@sindresorhus/slugify": "^0.2.0",
 		"crypto-random-string": "^1.0.0",
-		"electron-better-ipc": "^0.1.0",
+		"electron-better-ipc": "^0.1.1",
 		"electron-context-menu": "^0.9.1",
 		"electron-debug": "^1.5.0",
 		"electron-serve": "^0.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -172,9 +172,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-electron-better-ipc@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/electron-better-ipc/-/electron-better-ipc-0.1.0.tgz#0692f062169f52ca0014948fca0f4f5358e53e4b"
+electron-better-ipc@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/electron-better-ipc/-/electron-better-ipc-0.1.1.tgz#36c54a20499ecb061564ac82c054e88611b90efb"
 
 electron-context-menu@^0.9.1:
   version "0.9.1"


### PR DESCRIPTION
I was pulling my hair out on this one. I think I tried everything. At last I looked into the `node_modules` directory inside the app bundle, and turns out `electron` was a dependency there. That seemed wrong. Apparently if a module has a peerDependency on `electron`, Yarn or electron-builder will include it in the bundle... Fixed in https://github.com/sindresorhus/electron-better-ipc/commit/ff53a00ed05889a671f1b0d69b872294af51ef3c