### PR TITLE
Build `alicespend` swap TX

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -114,6 +114,13 @@ class SwapDB {
 			if (message.method === 'tradestatus' && message.status === 'finished') {
 				swap.status = 'completed';
 
+				swap.transactions.push({
+					stage: 'alicespend',
+					coin: message.bob,
+					txid: message.paymentspent,
+					amount: message.srcamount,
+				});
+
 				swap.executed.baseCurrencyAmount = roundTo(message.srcamount, 8);
 				swap.executed.quoteCurrencyAmount = roundTo(message.destamount, 8);
 				swap.executed.price = roundTo(message.destamount / message.srcamount, 8);

--- a/app/renderer/swap-transactions.js
+++ b/app/renderer/swap-transactions.js
@@ -1,3 +1,3 @@
-const swapTransactions = ['myfee', 'bobdeposit', 'alicepayment', 'bobpayment'];
+const swapTransactions = ['myfee', 'bobdeposit', 'alicepayment', 'bobpayment', 'alicespend'];
 
 export default swapTransactions;


### PR DESCRIPTION
We don't get a message for the `alicespend` TX but we get enough information in the `completed` message to create an `alicespend` object in our `transactions` array.

This allows us to give a full overview of the whole atomic swap process.

It also improves UX a bit as currently in the Exchange view you wait on `swap 4/4` for a while and then it jumps to completed. Which is kind of confusing, 4/4 seems like it should already be complete. With this change you'll be waiting on 4/5 and then it'll jump to completed, you never see 5/5 as a status because 5/5 is the final TX.