### PR TITLE
Show executed swap values in Swaps.js when available

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -73,6 +73,9 @@ class SwapDB {
 			statusFormatted: 'pending',
 			baseCurrency: response.base,
 			quoteCurrency: response.rel,
+			baseCurrencyAmount: roundTo(response.basevalue, 8),
+			quoteCurrencyAmount: roundTo(response.relvalue, 8),
+			price: roundTo(response.relvalue / response.basevalue, 8),
 			requested: {
 				baseCurrencyAmount: roundTo(request.amount, 8),
 				quoteCurrencyAmount: roundTo(request.total, 8),
@@ -121,9 +124,12 @@ class SwapDB {
 					amount: message.srcamount,
 				});
 
-				swap.executed.baseCurrencyAmount = roundTo(message.srcamount, 8);
-				swap.executed.quoteCurrencyAmount = roundTo(message.destamount, 8);
-				swap.executed.price = roundTo(message.destamount / message.srcamount, 8);
+				swap.baseCurrencyAmount = roundTo(message.srcamount, 8);
+				swap.quoteCurrencyAmount = roundTo(message.destamount, 8);
+				swap.price = roundTo(message.destamount / message.srcamount, 8);
+				swap.executed.baseCurrencyAmount = swap.baseCurrencyAmount;
+				swap.executed.quoteCurrencyAmount = swap.quoteCurrencyAmount;
+				swap.executed.price = swap.price;
 			}
 
 			if (message.method === 'failed') {

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -38,8 +38,8 @@ const SwapItem = ({swap}) => (
 	<div className="row">
 		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD.MM')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
-		<div className="sell-amount">-{swap.executed.quoteCurrencyAmount || swap.broadcast.quoteCurrencyAmount} {swap.quoteCurrency}</div>
-		<div className="buy-amount">+{swap.executed.baseCurrencyAmount || swap.broadcast.baseCurrencyAmount} {swap.baseCurrency}</div>
+		<div className="sell-amount">-{swap.quoteCurrencyAmount} {swap.quoteCurrency}</div>
+		<div className="buy-amount">+{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
 		<div className="status">
 			<div className="status__icon" data-status={swap.status}>{swap.statusFormatted}</div>
 		</div>


### PR DESCRIPTION
Currently the swap list on the Exchange view always shows the broadcasted values. We should update to the actual executed values as soon as the swap has completed.