### PR TITLE
Stop using deprecated React lifecycle hooks

### DIFF
--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -10,6 +10,10 @@ const fractionCount = string => {
 };
 
 class Input extends React.Component {
+	static getDerivedStateFromProps(props, state) {
+		return props.value === state.value ? null : {value: props.value};
+	}
+
 	state = {
 		value: this.props.value || '',
 	};
@@ -65,12 +69,6 @@ class Input extends React.Component {
 		}
 
 		return value;
-	}
-
-	componentWillReceiveProps(nextProps) {
-		if (nextProps.value !== this.state.value) {
-			this.setState({value: nextProps.value});
-		}
 	}
 
 	render() {

--- a/app/renderer/components/Modal.js
+++ b/app/renderer/components/Modal.js
@@ -11,19 +11,29 @@ class Modal extends React.Component {
 		delay: 400,
 	};
 
+	static getDerivedStateFromProps(props, state) {
+		if (!state.open && props.open) {
+			return {
+				isOpen: true,
+				animationType: 'open',
+			};
+		}
+
+		if (state.open && !props.open) {
+			if (props.onClose) {
+				props.onClose();
+			}
+
+			return {animationType: 'close'};
+		}
+	}
+
 	state = {
 		isOpen: false,
 		animationType: 'close',
 	};
 
 	elementRef = React.createRef();
-
-	openHandler = () => {
-		this.setState({
-			isOpen: true,
-			animationType: 'open',
-		});
-	};
 
 	closeHandler = () => {
 		if (this.props.onClose) {
@@ -64,14 +74,6 @@ class Modal extends React.Component {
 			if (input) {
 				input.focus();
 			}
-		}
-	}
-
-	componentWillReceiveProps(nextProps) {
-		if (!this.props.open && nextProps.open) {
-			this.openHandler();
-		} else if (this.props.open && !nextProps.open) {
-			this.closeHandler();
 		}
 	}
 

--- a/app/renderer/components/Modal.js
+++ b/app/renderer/components/Modal.js
@@ -12,22 +12,22 @@ class Modal extends React.Component {
 	};
 
 	static getDerivedStateFromProps(props, state) {
-		if (!state.open && props.open) {
-			return {
-				isOpen: true,
-				animationType: 'open',
-			};
+		const isClosed = !state.isOpen || (state.isOpen && state.animationType === 'close');
+		const isOpening = isClosed && props.open;
+		const isClosing = !isClosed && !props.open;
+
+		if (!isClosing && !isOpening) {
+			return null;
 		}
 
-		if (state.open && !props.open) {
-			if (props.onClose) {
-				props.onClose();
-			}
-
-			return {animationType: 'close'};
+		if (isClosing && props.onClose) {
+			props.onClose();
 		}
 
-		return null;
+		return {
+			...isOpening ? {isOpen: true} : {},
+			animationType: isOpening ? 'open' : 'close',
+		};
 	}
 
 	state = {

--- a/app/renderer/components/Modal.js
+++ b/app/renderer/components/Modal.js
@@ -26,6 +26,8 @@ class Modal extends React.Component {
 
 			return {animationType: 'close'};
 		}
+
+		return null;
 	}
 
 	state = {

--- a/app/renderer/components/TextArea.js
+++ b/app/renderer/components/TextArea.js
@@ -3,6 +3,10 @@ import {classNames} from 'react-extras';
 import './TextArea.scss';
 
 class TextArea extends React.Component {
+	static getDerivedStateFromProps(props, state) {
+		return props.value === state.value ? null : {value: props.value};
+	}
+
 	state = {
 		value: this.props.value,
 	};
@@ -35,12 +39,6 @@ class TextArea extends React.Component {
 			}
 		});
 	};
-
-	componentWillReceiveProps(nextProps) {
-		if (nextProps.value !== this.state.value) {
-			this.setState({value: nextProps.value});
-		}
-	}
 
 	render() {
 		let {

--- a/app/renderer/components/Tooltip.js
+++ b/app/renderer/components/Tooltip.js
@@ -29,12 +29,6 @@ class Tooltip extends React.PureComponent {
 		isOpen: false,
 	}
 
-	componentWillReceiveProps({content}) {
-		if (typeof this.updatePopper === 'function' && this.props.content !== content) {
-			this.updatePopper();
-		}
-	}
-
 	handleMouseEnter = () => {
 		this.setState({isOpen: true});
 	}
@@ -46,6 +40,11 @@ class Tooltip extends React.PureComponent {
 	render() {
 		const {animationDuration, children, content, margin, onClose, position} = this.props;
 		const {isOpen} = this.state;
+
+		if (typeof this.updatePopper === 'function') {
+			this.updatePopper();
+		}
+
 		const tooltip = (
 			<Popper placement={position} modifiers={{offset: {offset: `0, ${margin}`}}}>
 				{({arrowProps, placement, ref, scheduleUpdate, style}) => {

--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -19,6 +19,8 @@ document.documentElement.classList.add(`os-${process.platform}`);
 
 render((
 	<Provider>
-		<App/>
+		<React.StrictMode>
+			<App/>
+		</React.StrictMode>
 	</Provider>
 ), document.querySelector('#root'));

--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -17,10 +17,9 @@ require('electron-unhandled')({
 // Enable OS specific styles
 document.documentElement.classList.add(`os-${process.platform}`);
 
+// TODO: Wrap `<App>` in `<React.StrictMode>` sometime in the future when external components are updated to support it
 render((
 	<Provider>
-		<React.StrictMode>
-			<App/>
-		</React.StrictMode>
+		<App/>
 	</Provider>
 ), document.querySelector('#root'));

--- a/package.json
+++ b/package.json
@@ -176,8 +176,7 @@
 			"unicorn/filename-case": "off",
 			"import/exports-last": "error",
 			"react/prop-types": "off",
-			"react/require-default-props": "off",
-			"react/no-deprecated": "off"
+			"react/require-default-props": "off"
 		}
 	},
 	"stylelint": {


### PR DESCRIPTION
We have some third party components that causes some noise when using strict mode, but our components should be okay at least.

Fixes #373.