### PR TITLE
Automatically fix stuck swaps

### DIFF
--- a/app/locales/en-US/swap.json
+++ b/app/locales/en-US/swap.json
@@ -4,6 +4,8 @@
 	"timedOut": "Swap timed out",
 	"title": "Swap",
 	"details": {
+		"aliceclaim": "Alice Claim",
+		"alicereclaim": "Alice Reclaim",
 		"alicepayment": "Alice Payment",
 		"alicespend": "Alice Spend",
 		"bobdeposit": "Bob Deposit",

--- a/app/locales/en-US/swap.json
+++ b/app/locales/en-US/swap.json
@@ -37,6 +37,7 @@
 		"completed": "Completed",
 		"failed": "Failed",
 		"matched": "Matched",
+		"reverted": "Reverted",
 		"pending": "Pending",
 		"unmatched": "Unmatched"
 	}

--- a/app/locales/en-US/swap.json
+++ b/app/locales/en-US/swap.json
@@ -40,5 +40,8 @@
 		"reverted": "Reverted",
 		"pending": "Pending",
 		"unmatched": "Unmatched"
+	},
+	"statusInformation": {
+		"reverted": "The swap was reverted due to connectivity issues."
 	}
 }

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -376,14 +376,4 @@ export default class Api {
 		this.queue.pause();
 		this.queue.clear();
 	}
-
-	subscribeToSwap(uuid) {
-		ow(uuid, uuidPredicate.label('uuid'));
-
-		if (!this.socket) {
-			throw new Error('Swap subscriptions require the socket to be enabled');
-		}
-
-		return this.socket.subscribeToSwap(uuid);
-	}
 }

--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -350,6 +350,17 @@ export default class Api {
 		return getCurrency(opts.symbol).etomic ? this._withdrawEth(opts) : this._withdrawBtcFork(opts);
 	}
 
+	kickstart(opts) {
+		ow(opts.requestId, ow.number.positive.finite.label('requestId'));
+		ow(opts.quoteId, ow.number.positive.finite.label('quoteId'));
+
+		return this.request({
+			method: 'kickstart',
+			requestid: opts.requestId,
+			quoteid: opts.quoteId,
+		});
+	}
+
 	listUnspent(coin, address) {
 		ow(coin, symbolPredicate.label('coin'));
 		ow(address, ow.string.label('address'));

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -63,7 +63,7 @@ class SwapDetails extends React.Component {
 		));
 
 		if (swap.status === 'swapping') {
-			swapTransactions.forEach((stage, i) => {
+			swapTransactions.forEach(stage => {
 				const tx = swap.transactions.find(tx => tx.stage === stage);
 
 				if (!tx) {

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -52,33 +52,32 @@ class SwapDetails extends React.Component {
 		const {swap} = this.props;
 		const {baseCurrency, quoteCurrency} = swap;
 
-		let hasTransactions = false;
-		const transactions = swapTransactions.map(stage => {
-			const tx = swap.transactions.find(tx => tx.stage === stage);
+		const transactions = swap.transactions.map(tx => (
+			<React.Fragment key={tx.stage}>
+				<div className="arrow completed">→</div>
+				<div className="item completed" title={tx.txid}>
+					<h6>{t(`details.${tx.stage}`)}</h6>
+					<p>{tx.amount}<br/>{tx.coin}</p>
+				</div>
+			</React.Fragment>
+		));
 
-			if (!tx) {
-				return (
-					<React.Fragment key={stage}>
-						<div className="arrow">→</div>
-						<div className="item">
-							<h6>{t(`details.${stage}`)}</h6>
-						</div>
-					</React.Fragment>
-				);
-			}
+		if (swap.status === 'swapping') {
+			swapTransactions.forEach((stage, i) => {
+				const tx = swap.transactions.find(tx => tx.stage === stage);
 
-			hasTransactions = true;
-
-			return (
-				<React.Fragment key={stage}>
-					<div className="arrow completed">→</div>
-					<div className="item completed" title={tx.txid}>
-						<h6>{t(`details.${stage}`)}</h6>
-						<p>{tx.amount}<br/>{tx.coin}</p>
-					</div>
-				</React.Fragment>
-			);
-		});
+				if (!tx) {
+					transactions.push(
+						<React.Fragment key={stage}>
+							<div className="arrow">→</div>
+							<div className="item">
+								<h6>{t(`details.${stage}`)}</h6>
+							</div>
+						</React.Fragment>
+					);
+				}
+			});
+		}
 
 		const prices = ['requested', 'broadcast', 'executed'].map(value => {
 			if (!swap[value].price) {
@@ -151,7 +150,7 @@ class SwapDetails extends React.Component {
 									</p>
 								)}
 							</div>
-							{hasTransactions && (
+							{(transactions.length > 0) && (
 								<React.Fragment>
 									<h4>{t('details.transactions')}</h4>
 									<div className="transactions">

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -135,6 +135,9 @@ class SwapDetails extends React.Component {
 									</React.Fragment>
 								)}
 							</p>
+							{swap.statusInformation && (
+								<p>{swap.statusInformation}</p>
+							)}
 						</div>
 						<div className="section details">
 							<div className="offer-wrapper">

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -38,10 +38,9 @@ class ExchangeContainer extends SuperContainer {
 			}
 		});
 
-		const FIFTEEN_MINUTES = 1000 * 60 * 15;
-		fireEvery(async () => {
+		fireEvery({minutes: 15}, async () => {
 			await this.kickstartStuckSwaps();
-		}, FIFTEEN_MINUTES);
+		});
 	}
 
 	constructor() {

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -40,8 +40,7 @@ class ExchangeContainer extends SuperContainer {
 
 		const ONE_HOUR = 1000 * 60 * 60;
 		fireEvery(async () => {
-			// Disable this while we test swap incentive flaw
-			// await this.kickstartStuckSwaps();
+			await this.kickstartStuckSwaps();
 		}, ONE_HOUR);
 	}
 

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -40,7 +40,8 @@ class ExchangeContainer extends SuperContainer {
 
 		const ONE_HOUR = 1000 * 60 * 60;
 		fireEvery(async () => {
-			await this.kickstartStuckSwaps();
+			// Disable this while we test swap incentive flaw
+			// await this.kickstartStuckSwaps();
 		}, ONE_HOUR);
 	}
 

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -38,10 +38,10 @@ class ExchangeContainer extends SuperContainer {
 			}
 		});
 
-		const ONE_HOUR = 1000 * 60 * 60;
+		const FIFTEEN_MINUTES = 1000 * 60 * 15;
 		fireEvery(async () => {
 			await this.kickstartStuckSwaps();
-		}, ONE_HOUR);
+		}, FIFTEEN_MINUTES);
 	}
 
 	constructor() {

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -72,7 +72,7 @@ class ExchangeContainer extends SuperContainer {
 			))
 			.forEach(async swap => {
 				const {requestId, quoteId} = swap;
-				const result = await appContainer.api.kickstart({requestId, quoteId});
+				await appContainer.api.kickstart({requestId, quoteId});
 			});
 
 		if (!doneInitialKickstart) {

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -31,6 +31,7 @@ class ExchangeContainer extends SuperContainer {
 		appContainer.api.socket.on('message', message => {
 			const uuids = this.state.swapHistory.map(swap => swap.uuid);
 			if (uuids.includes(message.uuid)) {
+				console.log(message.method, message);
 				appContainer.swapDB.updateSwapData(message);
 			}
 		});

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -33,7 +33,6 @@ class ExchangeContainer extends SuperContainer {
 		appContainer.api.socket.on('message', message => {
 			const uuids = this.state.swapHistory.map(swap => swap.uuid);
 			if (uuids.includes(message.uuid)) {
-				console.log(message.method, message);
 				appContainer.swapDB.updateSwapData(message);
 			}
 		});

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -28,6 +28,12 @@ class ExchangeContainer extends SuperContainer {
 	componentDidInitialMount() {
 		this.setSwapHistory();
 		appContainer.swapDB.on('change', this.setSwapHistory);
+		appContainer.api.socket.on('message', message => {
+			const uuids = this.state.swapHistory.map(swap => swap.uuid);
+			if (uuids.includes(message.uuid)) {
+				appContainer.swapDB.updateSwapData(message);
+			}
+		});
 	}
 
 	constructor() {

--- a/app/renderer/marketmaker-socket.js
+++ b/app/renderer/marketmaker-socket.js
@@ -1,8 +1,6 @@
 import Emittery from 'emittery';
 import pEvent from 'p-event';
 import readBlob from 'read-blob';
-import pAny from 'p-any';
-import delay from 'delay';
 
 class MarketmakerSocket {
 	constructor(endpoint) {

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -108,6 +108,8 @@ class SwapDB {
 
 		const swap = {
 			uuid,
+			requestId: undefined,
+			quoteId: undefined,
 			timeStarted,
 			orderType: isBuyOrder ? 'buy' : 'sell',
 			status: 'pending',
@@ -144,6 +146,13 @@ class SwapDB {
 		};
 
 		messages.forEach(message => {
+			if (message.requestid) {
+				swap.requestId = message.requestid;
+			}
+			if (message.quoteid) {
+				swap.quoteId = message.quoteid;
+			}
+
 			if (message.method === 'connected') {
 				swap.status = 'matched';
 				swap.progress = MATCHED_STEP / TOTAL_PROGRESS_STEPS;

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -161,7 +161,7 @@ class SwapDB {
 			if (message.method === 'update') {
 				swap.status = 'swapping';
 				// Don't push duplicate messages
-				if(!swap.transactions.some(tx => tx.stage === message.name)) {
+				if(!swap.transactions.map(tx => tx.stage).includes(message.name)) {
 					swap.transactions.push({
 						stage: message.name,
 						coin: message.coin,

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -324,6 +324,7 @@ class SwapDB {
 		if (swap.status === 'completed') {
 			if (swap.transactions.find(tx => tx.stage === 'alicereclaim')) {
 				swap.statusFormatted = t('status.reverted').toLowerCase();
+				swap.statusInformation = t('statusInformation.reverted');
 			}
 		}
 

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -193,7 +193,7 @@ class SwapDB {
 					swap.transactions.push({
 						stage: 'myfee',
 						coin: message.alice,
-						txid: undefined, // This is currently mising from marketmaker responses
+						txid: message.alicedexfee,
 						amount: amounts.myfee,
 					});
 				}

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -192,7 +192,7 @@ class SwapDB {
 					swap.transactions.push({
 						stage: 'myfee',
 						coin: message.alice,
-						txid: undefined,
+						txid: undefined, // This is currently mising from marketmaker responses
 						amount: amounts.myfee,
 					});
 				}

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -161,7 +161,7 @@ class SwapDB {
 			if (message.method === 'update') {
 				swap.status = 'swapping';
 				// Don't push duplicate messages
-				if (!swap.transactions.map(tx => tx.stage).includes(message.name)) {
+				if (!swap.transactions.find(tx => tx.stage === message.name)) {
 					swap.transactions.push({
 						stage: message.name,
 						coin: message.coin,

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -258,6 +258,14 @@ class SwapDB {
 					});
 				}
 
+				// Overrride status to failed if we don't have a successful completion transaction
+				if (!(
+					message.sentflags.includes('alicespend') ||
+					message.sentflags.includes('aliceclaim')
+				)) {
+					swap.status = 'failed';
+				}
+
 				const startTx = swap.transactions.find(tx => tx.stage === 'alicepayment');
 				const startAmount = startTx ? startTx.amount : 0;
 				const endTx = swap.transactions.find(tx => ['alicespend', 'aliceclaim'].includes(tx.stage));
@@ -319,9 +327,6 @@ class SwapDB {
 			if (swap.error.code === -9999 || timedOut) {
 				swap.statusFormatted = t('status.unmatched').toLowerCase();
 			}
-		}
-
-		if (swap.status === 'completed') {
 			if (swap.transactions.find(tx => tx.stage === 'alicereclaim')) {
 				swap.statusFormatted = t('status.reverted').toLowerCase();
 				swap.statusInformation = t('statusInformation.reverted');

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -160,12 +160,15 @@ class SwapDB {
 
 			if (message.method === 'update') {
 				swap.status = 'swapping';
-				swap.transactions.push({
-					stage: message.name,
-					coin: message.coin,
-					txid: message.txid,
-					amount: message.amount,
-				});
+				// Don't push duplicate messages
+				if(!swap.transactions.some(tx => tx.stage === message.name)) {
+					swap.transactions.push({
+						stage: message.name,
+						coin: message.coin,
+						txid: message.txid,
+						amount: message.amount,
+					});
+				}
 			}
 
 			if (message.method === 'tradestatus' && message.status === 'finished') {

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -231,11 +231,15 @@ class SwapDB {
 				// This is the final tx in the case that bob doesn't send bobpayment.
 				// We can claim bobdeposit which gives us a 12.5% bonus to punish bob.
 				if (message.sentflags.includes('aliceclaim')) {
+					// There is a bug in marketmaker where it doesn't always correctly report
+					// the values. If aliceclaim is 0 we fallback to bobdeposit as it should
+					// be very close (same amount minus our claim txfee)
+					// https://github.com/jl777/SuperNET/issues/920
 					swap.transactions.push({
 						stage: 'aliceclaim',
 						coin: message.bob,
 						txid: message.depositspent,
-						amount: amounts.aliceclaim,
+						amount: amounts.aliceclaim || amounts.bobdeposit,
 					});
 				}
 

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -185,7 +185,7 @@ class SwapDB {
 				})();
 
 				swap.transactions = [];
-				if (amounts.myfee > 0) {
+				if (message.sentflags.includes('myfee')) {
 					swap.transactions.push({
 						stage: 'myfee',
 						coin: message.alice,
@@ -193,7 +193,7 @@ class SwapDB {
 						amount: amounts.myfee,
 					});
 				}
-				if (amounts.bobdeposit > 0) {
+				if (message.sentflags.includes('bobdeposit')) {
 					swap.transactions.push({
 						stage: 'bobdeposit',
 						coin: message.bob,
@@ -201,7 +201,7 @@ class SwapDB {
 						amount: amounts.bobdeposit,
 					});
 				}
-				if (amounts.alicepayment > 0) {
+				if (message.sentflags.includes('alicepayment')) {
 					swap.transactions.push({
 						stage: 'alicepayment',
 						coin: message.alice,
@@ -209,7 +209,7 @@ class SwapDB {
 						amount: amounts.alicepayment,
 					});
 				}
-				if (amounts.bobpayment > 0) {
+				if (message.sentflags.includes('bobpayment')) {
 					swap.transactions.push({
 						stage: 'bobpayment',
 						coin: message.bob,
@@ -219,7 +219,7 @@ class SwapDB {
 				}
 
 				// This is the final tx claiming bobpayment for a trade that completed as expected.
-				if (amounts.alicespend > 0) {
+				if (message.sentflags.includes('alicespend')) {
 					swap.transactions.push({
 						stage: 'alicespend',
 						coin: message.bob,
@@ -230,7 +230,7 @@ class SwapDB {
 
 				// This is the final tx in the case that bob doesn't send bobpayment.
 				// We can claim bobdeposit which gives us a 12.5% bonus to punish bob.
-				if (amounts.aliceclaim > 0) {
+				if (message.sentflags.includes('aliceclaim')) {
 					swap.transactions.push({
 						stage: 'aliceclaim',
 						coin: message.bob,
@@ -242,7 +242,7 @@ class SwapDB {
 				// This is the final tx in the case that bob doesn't send anything after
 				// we've already sent alicepayment. We don't get any of the currency we
 				// want, just claim our original payment back.
-				if (amounts.alicereclaim > 0) {
+				if (message.sentflags.includes('alicereclaim')) {
 					swap.transactions.push({
 						stage: 'alicereclaim',
 						coin: message.alice,

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -313,8 +313,18 @@ class SwapDB {
 
 			swap.statusFormatted = `swap ${swapProgress}/${swapTransactions.length}`;
 			swap.progress = (swapProgress + MATCHED_STEP) / TOTAL_PROGRESS_STEPS;
-		} else if (swap.status === 'failed' && (swap.error.code === -9999 || timedOut)) {
-			swap.statusFormatted = t('status.unmatched').toLowerCase();
+		}
+
+		if (swap.status === 'failed') {
+			if (swap.error.code === -9999 || timedOut) {
+				swap.statusFormatted = t('status.unmatched').toLowerCase();
+			}
+		}
+
+		if (swap.status === 'completed') {
+			if (swap.transactions.find(tx => tx.stage === 'alicereclaim')) {
+				swap.statusFormatted = t('status.reverted').toLowerCase();
+			}
 		}
 
 		return swap;

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -93,6 +93,7 @@ class SwapDB {
 		});
 	}
 
+	// TODO: We should refactor this into a seperate file
 	_formatSwap(data) {
 		const MATCHED_STEP = 1;
 		const TOTAL_PROGRESS_STEPS = swapTransactions.length + MATCHED_STEP;

--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -161,7 +161,7 @@ class SwapDB {
 			if (message.method === 'update') {
 				swap.status = 'swapping';
 				// Don't push duplicate messages
-				if(!swap.transactions.map(tx => tx.stage).includes(message.name)) {
+				if (!swap.transactions.map(tx => tx.stage).includes(message.name)) {
 					swap.transactions.push({
 						stage: message.name,
 						coin: message.coin,

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -144,7 +144,6 @@ class Bottom extends React.Component {
 
 		const swap = result.pending;
 		const {swapDB} = appContainer;
-		api.subscribeToSwap(swap.uuid).on('progress', console.log);
 		await swapDB.insertSwapData(swap, requestOpts);
 		exchangeContainer.setIsSendingOrder(false);
 	};

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -144,7 +144,7 @@ class Bottom extends React.Component {
 
 		const swap = result.pending;
 		const {swapDB} = appContainer;
-		api.subscribeToSwap(swap.uuid).on('progress', swapDB.updateSwapData);
+		api.subscribeToSwap(swap.uuid).on('progress', console.log);
 		await swapDB.insertSwapData(swap, requestOpts);
 		exchangeContainer.setIsSendingOrder(false);
 	};


### PR DESCRIPTION
Resolves #163 

This PR resolves the issue of users getting swaps that are stuck mid swap (e.g in `swap 3/5` state).

If a swap fails due to connectivity issues or closing the app the swap would become "stuck". Although the funds were cryptographically safe and reclaimable via the atomic swap protocol, `marketmaker` wouldn't actually reclaim the funds automatically without custom intervention via the console or CLI.

We are now manually looping over old swaps every 15 mins that are in a stuck state and "kickstarting" them to get `marketmaker` to recheck the status.

There are quite a lot of changes required to the current code base to get this working. I will try and break down the changes here and explain why they are necessary.

**Get updates on stuck swaps** https://github.com/hyperdexapp/hyperdex/pull/416/commits/1e7ceeea29c87658c7482767f09635375061cb00 https://github.com/hyperdexapp/hyperdex/pull/416/commits/5eaedd9dab0585a8836ff4e0bcdfc22739cf4ab0

We were previously listening for updates over the socket for a swap by adding a new event listener for each swap that listens out for messages containing it's UUID. This was not a great approach and resulted in a few crazy hacks to avoid memory leaks whilst also correctly handling quirky `marketmaker` behaviour where a swap would be reported as failed and the event listener was removed, only to later send us a completion message.

Now we only attach a single event listener and check all messages against a list of all known swap UUIDs. This means we can guarantee we will always catch updates to swaps, if they were started in a previous session and even if they are received in a strange order, e.g failed then complete. It's also much simpler code and avoids risks of memory leaks having a large amount of event listeners.

**Force kickstart stuck swaps** https://github.com/hyperdexapp/hyperdex/pull/416/commits/2e89499a46f768587ba98b41acc27d50f001e0e1 https://github.com/hyperdexapp/hyperdex/pull/416/commits/6514951a9634a24ba0455b3ffceab593773fb945

This is supposed to be handled automatically by `marketmaker`, but I've never personally seen it actually work. What we now do is loops over all swaps that are currently swapping and were started over 4 hours ago, then call `marketmaker`'s `kickstart` method. This forces it to check the current state of the swap and if something has gone wrong or Bob hasn't responded it will attempt to reclaim the funds from the timelocked address. This is why we only check if the swap is over 4 hours old, because the timelocks last 4 hours. We do this instantly on startup and then check again every 15 minutes.

On the first startup check, we check all pending swaps, even if they weren't started over 4 hours ago, this is because there are some scenarios where a swap can be reverted sooner.

This means you don't need to keep HyperDEX (and `marketmaker` running). You can close the app, open it the next day, and it will instantly reclaim your stuck swap if possible.

**Recalculate the state of a completed swap** https://github.com/hyperdexapp/hyperdex/pull/416/commits/fc1caab826820055f37fd2b6e1edc06691797c51 https://github.com/hyperdexapp/hyperdex/pull/416/commits/45b5b4910a0534bad2ea7b5e36bff7de6ea59174

Due to the fact that HyperDEX (and `marketmaker`) might not be running for the entire swap, we can't rely on the WebSocket message history to provide an accurate overview of what happened during the swap. The completed message we get at the end of every normal swap and "kickstarted" stuck swaps contains all the information we need to rebuild the full history of what happened.

So we now have two ways of building a formatted swap object. The socket messages are used while a swap is in progress. Once a swap is completed, the final completed socket message is used to reconstruct the entire swap transaction history and state which we know contains all data. The resulting structure of the swap object follows the same pattern in both methods so all existing UI code works no matter how the swap data was calculated.

This means if a swap is completed it should never have missing tx data, it should always list the entire chain of TXs, even if it wasn't online the whole time. It also means we correctly handle weird states like when the swap doesn't go to plan and we reclaim our original payment or claim `bobdeposit` instead of `bobpayment`. It also abstracts out quite a few quirks in `marketmaker` responses.

**Showing kickstarted swaps TXs in the swap modal** https://github.com/hyperdexapp/hyperdex/pull/416/commits/1a95811756701e33c139d2bb7cb3abdef431527c https://github.com/hyperdexapp/hyperdex/pull/416/commits/0e55952d967f4cd0afe2363e8fd678a66c8c70da

Kickstarted swaps don't always have the same transactions exposed as our current code expects which breaks the modal layout. I've modified the transactions array to not allow duplicate transactions (sometimes `marketmaker` sends multiple messages for the same TX which we were pushing into the transactions array). This means while the swap is in progress we can rely on just looping over the transaction array for the current data are less the 5 items fill them in with the placeholders.

Once a swap is completed however, there may not be 5 transactions due to the reversion and we don't want to show the placeholder boxes as those transactions are no longer expected to occur. However the reversion transactions are handled by the completed message and added to the transactions array, so just looping over that means they will show up, we just skip showing the placeholder boxes.

---

There's also a few other bits handling weird mm responses and adding extra data for stuck swaps, but they're fairly self explanatory.

To show how successfully resumed swaps look in the UI:

**A swap that was stuck, but then resumed in time to proceed as normal**

By either a reboot, losing network connectivity, accidentally closing the app etc.

This swap appears just like a normal swap that completed without issue:

<img width="608" alt="screen shot 2018-07-12 at 3 21 59 pm" src="https://user-images.githubusercontent.com/2123375/42621378-d46a7a94-85e7-11e8-8f30-b977b55e91fc.png">

<img width="697" alt="screen shot 2018-07-12 at 3 22 11 pm" src="https://user-images.githubusercontent.com/2123375/42621389-da408fb2-85e7-11e8-9628-09909c73b438.png">

*Notice the final TX is `alicespend`, the expected TX for a successful swap*

**A swap that was stuck due to Bob not sending `bobpayment`**

If Bob doesn't send `bobpayment` you need to wait four hours for the timelock on `bobdeposit` to expire. The we can claim `bobdeposit` with an `aliceclaim` TX. `bobdepost` is 12.5% more than the amount we were supposed to get. We get to keep this to punish Bob for being a dick. (In a normal trade Bob would reclaim his own `bobdeposit` after we spend `bobpayment` with `alicespend`).

You don't actually need to keep the app running for four hours though, you could go to bed and run the app in the morning and it will reclaim everything.

This swap appears just like a normal swap in the swap list. However in the modal it will show only four TXs in the TX chain and you'll notice that it shows a much higher percentage message than normal due to our 12.5% bonus:

<img width="610" alt="screen shot 2018-07-12 at 3 24 10 pm" src="https://user-images.githubusercontent.com/2123375/42621736-c1c5dc2a-85e8-11e8-8d32-88aca1f2c333.png">

<img width="691" alt="screen shot 2018-07-12 at 3 23 52 pm" src="https://user-images.githubusercontent.com/2123375/42621744-c52de4e8-85e8-11e8-8895-3a52a8a179f2.png">

*Notice the final TX is `aliceclaim` and is higher than what we asked for*

**A swap that was stuck due to Bob not sending any payments**

If Bob doesn't send any payments (`bobdeposit` or `bobpayment`) we can't really do much about it. We can reclaim our `alicepayment` funds but we lose our `dexfee` payment.

Although `marketmaker` reports the status as successfully completed (which kind of makes sense in terms of the atomic swap protocol), I'm mapping this to a failed swap in our logic because if the user doesn't get their desired funds, it's failed from their perspective.

So it will show in the swap list as reverted with the same styles as a failed/unmatched swap. The received value will be set as 0 and you will see the reclaim TX as the final TX in the chain. There is also a relatively vague message explaining what went wrong. (We really don't know what went wrong, it could have been many things):

<img width="606" alt="screen shot 2018-07-12 at 3 24 21 pm" src="https://user-images.githubusercontent.com/2123375/42622055-a00e2a5a-85e9-11e8-91bb-e27e9b2866c9.png">

<img width="691" alt="screen shot 2018-07-12 at 3 24 29 pm" src="https://user-images.githubusercontent.com/2123375/42622059-a2278ba6-85e9-11e8-9dca-955a55c58672.png">

*Notice the final TX is `alicereclaim` which just claims back our original funds*

---

As far as I'm aware, this correctly handles all stuck states and displays them correctly in the UI. You are guaranteed to either:

- Get the amount you were supposed to
- Get the amount you were supposed to + 12.5%
- Reclaim your original payment (but lose your `dexfee`)