### PR TITLE
Fix order selection calculation

### DIFF
--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -62,7 +62,11 @@ const Center = props => {
 		// This is just a quick fix to increase match rate
 		const percentMoreExpensive = 5 / 100;
 		const pricePercentage = price * percentMoreExpensive;
-		price = props.type === 'buy' ? price + pricePercentage : price - pricePercentage ;
+		if (props.type === 'buy') {
+			price += pricePercentage;
+		} else {
+			price -= pricePercentage;
+		}
 
 		return props.handlePriceChange(price);
 	};

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -56,7 +56,7 @@ const Center = props => {
 	const {state} = exchangeContainer;
 
 	const selectRow = row => {
-		let price = row.price;
+		let {price} = row;
 
 		// TODO: This should be fixed properly in mm or use more sensible logic here
 		// This is just a quick fix to increase match rate

--- a/app/renderer/views/Exchange/Order.js
+++ b/app/renderer/views/Exchange/Order.js
@@ -55,9 +55,17 @@ class Top extends React.Component {
 const Center = props => {
 	const {state} = exchangeContainer;
 
-	// TODO: This should be fixed properly in mm or use more sensible logic here
-	// This is just a quick fix to increase match rate for a demo
-	const selectRow = row => props.handlePriceChange(row.price * 1.05);
+	const selectRow = row => {
+		let price = row.price;
+
+		// TODO: This should be fixed properly in mm or use more sensible logic here
+		// This is just a quick fix to increase match rate
+		const percentMoreExpensive = 5 / 100;
+		const pricePercentage = price * percentMoreExpensive;
+		price = props.type === 'buy' ? price + pricePercentage : price - pricePercentage ;
+
+		return props.handlePriceChange(price);
+	};
 
 	return (
 		<div className="center">


### PR DESCRIPTION
When you click an order in the order book we add 5% to the price to increase the chances of getting matched.

However we should only be doing this on buy orders and instead **subtracting** 5% from sell orders.