### PR TITLE
Handle uncontrolled closing of modal

### DIFF
--- a/app/renderer/components/Modal.js
+++ b/app/renderer/components/Modal.js
@@ -12,11 +12,11 @@ class Modal extends React.Component {
 	};
 
 	static getDerivedStateFromProps(props, state) {
-		const isClosed = !state.isOpen || (state.isOpen && state.animationType === 'close');
-		const isOpening = isClosed && props.open;
-		const isClosing = !isClosed && !props.open;
+		const isClosed = (!state.isOpen || state.animationType === 'close') && !props.open;
+		const isOpening = !state.isOpen && props.open;
+		const isClosing = state.isOpen && (state.animationType === 'close' || !props.open);
 
-		if (!isClosing && !isOpening) {
+		if (isClosed || (!isClosing && !isOpening)) {
 			return null;
 		}
 


### PR DESCRIPTION
This fixes cases where the modal wouldn't close if it were uncontrolled, i.e. if we didn't explicitly pass in `open: false` in `onClose`.

![kapture 2018-07-17 at 21 01 34](https://user-images.githubusercontent.com/709159/42839746-f0aeeb24-8a04-11e8-8b0f-f0e0f67c3f92.gif)

![kapture 2018-07-17 at 21 03 29](https://user-images.githubusercontent.com/709159/42839740-ee319f72-8a04-11e8-84da-72e0693ba5ca.gif)