### PR TITLE
Add hotkey to restart HyperDEX in debug mode

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -35,3 +35,7 @@ $ ./signedchecksum
 ```
 
 It will create a file called `SHASUMS256.txt.asc` that you need to upload to the GitHub release manually.
+
+## Debug-mode in production
+
+Press <kbd>Control</kbd> <kbd>Shift</kbd> <kbd>Alt</kbd> <kbd>D</kbd> to relaunch HyperDEX in debug-mode. You can then access debug features in the Debug menu.

--- a/app/index.js
+++ b/app/index.js
@@ -28,7 +28,7 @@ try {
 	require('electron-reloader')(module, {watchRenderer: false});
 } catch (_) {}
 
-const {app, session} = electron;
+const {app, session, globalShortcut} = electron;
 
 app.setAppUserModelId('com.lukechilds.hyperdex');
 
@@ -145,7 +145,21 @@ if (!is.development) {
 	`);
 }
 
+const registerDebugHotkey = () => {
+	const debugShortcut = 'Control+Shift+Alt+D';
+
+	globalShortcut.register(debugShortcut, () => {
+		globalShortcut.unregister(debugShortcut);
+		app.relaunch({
+			args: process.argv.slice(1).concat(['--debug']),
+		});
+		app.quit();
+	});
+};
+
 app.on('ready', () => {
+	registerDebugHotkey();
+
 	session.defaultSession.setPermissionRequestHandler((webContents, permission, callback) => {
 		if (permission === 'notifications') {
 			callback(true);

--- a/app/util-common.js
+++ b/app/util-common.js
@@ -4,7 +4,7 @@ const {api} = require('electron-util');
 const isNightlyBuild = api.app.getName() === 'HyperDEX Nightly';
 
 /// TODO: Change this before the official launch
-/// const isDevelopment = is.development || isNightlyBuild;
+/// const isDevelopment = process.argv.slice(1).includes('--debug') || is.development || isNightlyBuild;
 const isDevelopment = true;
 
 module.exports = {


### PR DESCRIPTION
I first implemented this as a shortcut (Control+Shift) you hold down during app launch to activate debug-mode. Well, turns out you can't do shortcuts without a non-modifier ([#9900](https://github.com/electron/electron/issues/9900)) in Electron. Then there's the issue that Electron doesn't allow you to subscribe to shortcuts until `app.isReady()` ([#13716](https://github.com/electron/electron/issues/13716)), which is too late for us as we've already done the debug-mode check by then. Then I ended doing it so that you can press Control+Shift+Alt+D after the app has launched. Of course, our journey doesn't end there. Turns out there's an [`electron-builder` issue](https://github.com/electron-userland/electron-builder/issues/1727) which prevents the AppImage (Linux) from being relaunched. The ability to relaunch is important as we relaunch with the `--debug` flag to indicate debug-mode. I then considered moving the debug state from the `--debug` flag to saving it to our config and reading it back on launch and clear it out if it exists.

Before I waste more time on this. Do you think it should be a keyboard shortcut or should we maybe put it in the `Help` menu as `Debug Mode` that can be toggled?

// @lukechilds @kevva 