### PR TITLE
Pass `ref` to password input in `SeedPhraseModal`

### DIFF
--- a/app/renderer/views/Settings/SeedPhraseModal.js
+++ b/app/renderer/views/Settings/SeedPhraseModal.js
@@ -91,6 +91,7 @@ class SeedPhraseModal extends React.Component {
 						<form onSubmit={this.handleSubmit(modalRef)}>
 							<div className="form-group">
 								<Input
+									ref={this.passwordInputRef}
 									disabled={this.state.isVerifying}
 									errorMessage={this.state.passwordError}
 									placeholder={t('seedPhrase.enterPassword')}


### PR DESCRIPTION
Don't know how this got removed. But should work now again.

Fixes #429.