### PR TITLE
Add success/fail color to the progress bar in the swap modal

### DIFF
--- a/app/renderer/components/Progress.js
+++ b/app/renderer/components/Progress.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {classNames} from 'react-extras';
 import './Progress.scss';
 
-const Progress = ({value, showLabel, hideWhenZero, ...props}) => {
+const Progress = ({value, color, showLabel, hideWhenZero, ...props}) => {
 	if (value > 1 || value < 0) {
 		throw new TypeError('Expected a value in the range 0...1');
 	}
@@ -17,7 +17,7 @@ const Progress = ({value, showLabel, hideWhenZero, ...props}) => {
 
 	return (
 		<div {...props} className={className}>
-			<div className="Progress__bar" style={{width: percentageFormatted}}>
+			<div className="Progress__bar" style={{width: percentageFormatted, background: color}}>
 				{showLabel &&
 					<div className="Progress__label">{percentageFormatted}</div>
 				}

--- a/app/renderer/components/Progress.scss
+++ b/app/renderer/components/Progress.scss
@@ -10,7 +10,7 @@
 		width: 0;
 		height: 5px;
 		background: var(--progress-gradient);
-		transition: width 0.5s ease-in-out;
+		transition: width 0.5s, background 0.5s;
 	}
 
 	&__label {

--- a/app/renderer/components/SwapDetails.js
+++ b/app/renderer/components/SwapDetails.js
@@ -125,7 +125,13 @@ class SwapDetails extends React.Component {
 							</div>
 						</div>
 						<div className="section progress">
-							<Progress value={swap.progress}/>
+							<Progress
+								value={swap.progress}
+								color={
+									(swap.status === 'completed' && 'var(--success-color)') ||
+									(swap.status === 'failed' && 'var(--error-color)')
+								}
+							/>
 							<p>
 								{title(swap.statusFormatted)}
 								{(swap.status === 'failed' && swap.error) && (


### PR DESCRIPTION
The progress bar turns green when completed and red when there's an error.

![screen shot 2018-07-19 at 17 25 50](https://user-images.githubusercontent.com/170270/42937833-6b92022e-8b7a-11e8-83bf-37839dade39a.png)

![screen shot 2018-07-19 at 17 25 35](https://user-images.githubusercontent.com/170270/42937831-6b54ec5e-8b7a-11e8-9684-096784474706.png)