### PR TITLE
Limit the amount of swaps in the Exchange view

### DIFF
--- a/app/locales/en-US/exchange.json
+++ b/app/locales/en-US/exchange.json
@@ -29,6 +29,7 @@
 	"quit": "Quit",
 	"swaps": {
 		"all": "All",
-		"title": "Recent Swaps"
+		"title": "Recent Swaps",
+		"viewAllSwaps": "View all swaps"
 	}
 }

--- a/app/locales/en-US/exchange.json
+++ b/app/locales/en-US/exchange.json
@@ -29,6 +29,6 @@
 	"quit": "Quit",
 	"swaps": {
 		"all": "All",
-		"title": "Swaps"
+		"title": "Recent Swaps"
 	}
 }

--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -2,12 +2,14 @@ import {api} from 'electron-util';
 import React from 'react';
 import {format as formatDate} from 'date-fns';
 import appContainer from 'containers/App';
+import tradesContainer from 'containers/Trades';
 import Empty from 'components/Empty';
+import Link from 'components/Link';
 import SwapDetails from 'components/SwapDetails';
 import {translate} from '../translate';
 import './SwapList.scss';
 
-const t = translate('swap');
+const t = translate(['swap', 'exchange']);
 
 // eslint-disable-next-line no-unused-vars
 class CancelButton extends React.Component {
@@ -85,6 +87,17 @@ const SwapList = ({swaps, limit, showCancel}) => {
 						showCancel={showCancel}
 					/>
 				))
+			}
+			{limit &&
+				<Link
+					className="view-all-swaps"
+					onClick={() => {
+						appContainer.setActiveView('Trades');
+						tradesContainer.setActiveView('SwapHistory');
+					}}
+				>
+					{t('swaps.viewAllSwaps')}
+				</Link>
 			}
 		</div>
 	);

--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -66,9 +66,13 @@ const SwapItem = ({swap}) => (
 	</div>
 );
 
-const SwapList = ({swaps, showCancel}) => {
+const SwapList = ({swaps, limit, showCancel}) => {
 	if (swaps.length === 0) {
 		return <Empty show text={t('list.empty')}/>;
+	}
+
+	if (limit) {
+		swaps = swaps.slice(0, limit);
 	}
 
 	return (

--- a/app/renderer/components/SwapList.scss
+++ b/app/renderer/components/SwapList.scss
@@ -1,4 +1,6 @@
 .SwapList {
+	display: flex;
+	flex-direction: column;
 	flex: 1;
 	overflow-x: hidden;
 	overflow-y: auto;
@@ -181,6 +183,13 @@
 
 	.cancel :not([disabled]) {
 		filter: hue-rotate(130deg) saturate(160%);
+	}
+
+	.view-all-swaps {
+		align-self: center;
+		margin: 20px 0;
+		font-size: 14px;
+		opacity: 0.8;
 	}
 }
 

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -8,6 +8,8 @@ import './Swaps.scss';
 
 const t = translate('exchange');
 
+const swapLimit = 50;
+
 const TabButton = props => (
 	<span
 		className={
@@ -31,7 +33,7 @@ const TabView = ({component}) => (
 );
 
 const All = () => (
-	<SwapList swaps={exchangeContainer.state.swapHistory}/>
+	<SwapList swaps={exchangeContainer.state.swapHistory} limit={swapLimit}/>
 );
 
 const Split = () => {
@@ -43,7 +45,7 @@ const Split = () => {
 	);
 
 	return (
-		<SwapList swaps={filteredData}/>
+		<SwapList swaps={filteredData} limit={swapLimit}/>
 	);
 };
 


### PR DESCRIPTION
It's just naively slicing off what we need. This is not meant as a performance optimization, but rather to make it less noisy for the user. All swaps are available in the Trades view anyway.