### PR TITLE
Compare new `value` prop with previous when updating state

### DIFF
--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -11,8 +11,6 @@ const fractionCount = string => {
 
 class Input extends React.Component {
 	static getDerivedStateFromProps(props, state) {
-		console.log(state, 'state');
-
 		return props.value === state.prevValue ? null : {
 			value: props.value,
 			prevValue: props.value,

--- a/app/renderer/components/Input.js
+++ b/app/renderer/components/Input.js
@@ -11,7 +11,12 @@ const fractionCount = string => {
 
 class Input extends React.Component {
 	static getDerivedStateFromProps(props, state) {
-		return props.value === state.value ? null : {value: props.value};
+		console.log(state, 'state');
+
+		return props.value === state.prevValue ? null : {
+			value: props.value,
+			prevValue: props.value,
+		};
 	}
 
 	state = {

--- a/app/renderer/components/TextArea.js
+++ b/app/renderer/components/TextArea.js
@@ -4,7 +4,10 @@ import './TextArea.scss';
 
 class TextArea extends React.Component {
 	static getDerivedStateFromProps(props, state) {
-		return props.value === state.value ? null : {value: props.value};
+		return props.value === state.prevValue ? null : {
+			value: props.value,
+			prevValue: props.value,
+		};
 	}
 
 	state = {


### PR DESCRIPTION
Since we do some computations when setting the `value` state, it will differ when matching the `value` prop sometimes. Instead of matching `value`, we store the previous `value` prop as `prevValue` and match against that instead since we aren't doing any computations on it.

Fixes #432.