### PR TITLE
Add initial Touch Bar support

### DIFF
--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -4,6 +4,7 @@ import {render} from 'react-dom';
 import {Provider} from 'unstated';
 import UNSTATED from 'unstated-debug';
 import App from './views/App';
+import touchBar from './touch-bar';
 
 process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = true;
 
@@ -23,3 +24,5 @@ render((
 		<App/>
 	</Provider>
 ), document.querySelector('#root'));
+
+touchBar();

--- a/app/renderer/touch-bar.js
+++ b/app/renderer/touch-bar.js
@@ -1,0 +1,49 @@
+import {remote} from 'electron';
+import {appLaunchTimestamp} from 'electron-util';
+import title from 'title';
+import appContainer from 'containers/App';
+import dashboardContainer from 'containers/Dashboard';
+import exchangeContainer from 'containers/Exchange';
+import {translate} from './translate';
+
+const t = translate('swap');
+
+const {TouchBar} = remote;
+const {TouchBarLabel, TouchBarSpacer} = TouchBar;
+
+const portfolioValue = new TouchBarLabel();
+const latestSwap = new TouchBarLabel();
+
+const getLatestSwap = () => exchangeContainer.state.swapHistory.find(swap => swap.timeStarted > appLaunchTimestamp);
+
+const updateTouchBar = () => {
+	portfolioValue.label = `${appContainer.state.portfolio.name}: ${dashboardContainer.assetCount} ≈ ${dashboardContainer.totalAssetValueFormatted}`;
+
+	const swap = getLatestSwap();
+	latestSwap.label = swap ? `${swap.baseCurrency}/${swap.quoteCurrency} ${t(`details.${swap.orderType}`)} ${t('details.order')}: ${title(swap.statusFormatted)}` : '';
+
+	latestSwap.textColor = swap ? (
+		(swap.status === 'completed' && '#28af60' /* => var(--success-color) */) ||
+		(swap.status === 'failed' && '#f80759' /* => var(--error-color) */)
+	) : null;
+};
+
+const initTouchBar = () => {
+	const touchBar = new TouchBar([
+		portfolioValue,
+		new TouchBarSpacer({size: 'flexible'}),
+		latestSwap,
+	]);
+
+	remote.getCurrentWindow().setTouchBar(touchBar);
+
+	appContainer.subscribe(() => {
+		if (appContainer.isLoggedIn) {
+			updateTouchBar();
+		}
+	});
+
+	exchangeContainer.subscribe(updateTouchBar);
+};
+
+export default initTouchBar;


### PR DESCRIPTION
Related to #95. This is just minimal support so the Touch Bar is not empty. We can improve upon it later on.

It shows the portfolio name and total asset count and value. And it shows the latest swap.

<img width="1085" alt="touch bar shot 2018-08-01 at 18 35 32" src="https://user-images.githubusercontent.com/170270/43579373-188dacc4-967c-11e8-8fc0-691845a7ef6c.png">
