### PR TITLE
Add some useful readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@
 	<br>
 	<p>Desktop App for <a href="https://barterdex.supernet.org">BarterDEX</a></p>
 	<br>
+	<a title="Downloads" href="https://github.com/atomiclabs/hyperdex/releases/latest">
+		<img src="https://img.shields.io/github/downloads/atomiclabs/hyperdex/total.svg">
+	</a>
+	<a title="Crowdin" target="_blank" href="https://crowdin.com/project/hyperdex">
+		<img src="https://d322cqt584bo4o.cloudfront.net/hyperdex/localized.svg">
+	</a>
+	<a title="Discord" target="_blank" href="https://discord.gg/gBhBg6E">
+		<img src="https://img.shields.io/discord/<server-id>.svg">
+	</a>
+	<a title="MIT License" href="LICENSE">
+		<img src="https://img.shields.io/github/license/atomiclabs/hyperdex.svg">
+	</a>
+	<a href="Follow on Twitter" href="https://twitter.com/HyperDEXApp">
+		<img src="https://img.shields.io/twitter/follow/HyperDexApp.svg?style=social&label=Follow">
+	</a>
+	<br>
 	<br>
 	<br>
 </div>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 	<a title="Crowdin" target="_blank" href="https://crowdin.com/project/hyperdex">
 		<img src="https://d322cqt584bo4o.cloudfront.net/hyperdex/localized.svg">
 	</a>
-	<a title="Discord" target="_blank" href="https://discord.gg/gBhBg6E">
-		<img src="https://img.shields.io/discord/<server-id>.svg">
-	</a>
 	<a title="MIT License" href="LICENSE">
 		<img src="https://img.shields.io/github/license/atomiclabs/hyperdex.svg">
 	</a>


### PR DESCRIPTION
I'm aware the Crowdin badge doesn't totally fit in. I've emailed them about that.

The chat badge would show how many people we have in our Discord channel. But we need one of the admine to turn it on:

> In discord Server Server Settings -> Widget turn on Enable Server Widget switch. Below that, you will find SERVER ID.

Here's how it will look:


<img width="902" alt="screen shot 2018-08-03 at 15 37 33" src="https://user-images.githubusercontent.com/170270/43656889-46172ed8-977e-11e8-9cb1-fc9005eadb6e.png">
