### PR TITLE
Fix `Tooltip` memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"react-dom": "^16.4.2",
 		"react-extras": "^0.7.1",
 		"react-i18next": "^7.10.1",
-		"react-popper": "^1.0.0",
+		"react-popper": "^1.0.1",
 		"react-select": "^1.2.1",
 		"react-transition-group": "^2.4.0",
 		"react-virtualized": "^9.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7721,9 +7721,9 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
-react-popper@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.0.tgz#b99452144e8fe4acc77fa3d959a8c79e07a65084"
+react-popper@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.2.tgz#0e72f338b7f15ab9f9ec884e36ae0dad78a3e301"
   dependencies:
     babel-runtime "6.x.x"
     create-react-context "^0.2.1"


### PR DESCRIPTION
This was fixed upstream in https://github.com/FezVrasta/react-popper/pull/197.

Fixes #477.