### PR TITLE
Only show open orders on exchange view

### DIFF
--- a/app/locales/en-US/exchange.json
+++ b/app/locales/en-US/exchange.json
@@ -29,7 +29,7 @@
 	"quit": "Quit",
 	"swaps": {
 		"all": "All",
-		"title": "Recent Swaps",
+		"title": "Open Orders",
 		"viewAllSwaps": "View all swaps"
 	}
 }

--- a/app/renderer/containers/Exchange.js
+++ b/app/renderer/containers/Exchange.js
@@ -15,7 +15,7 @@ class ExchangeContainer extends SuperContainer {
 		return {
 			baseCurrency: 'CHIPS',
 			quoteCurrency: 'KMD',
-			activeSwapsView: 'All',
+			activeSwapsView: 'OpenOrders',
 			swapHistory: [],
 			orderBook: {
 				bids: [],

--- a/app/renderer/views/Exchange/Swaps.js
+++ b/app/renderer/views/Exchange/Swaps.js
@@ -10,6 +10,8 @@ const t = translate('exchange');
 
 const swapLimit = 50;
 
+const getOpenOrders = () => exchangeContainer.state.swapHistory.filter(swap => !['completed', 'failed'].includes(swap.status));
+
 const TabButton = props => (
 	<span
 		className={
@@ -32,16 +34,20 @@ const TabView = ({component}) => (
 	<View component={component} activeView={exchangeContainer.state.activeSwapsView}/>
 );
 
-const All = () => (
-	<SwapList swaps={exchangeContainer.state.swapHistory} limit={swapLimit} showCancel/>
-);
+const OpenOrders = () => {
+	const openOrders = getOpenOrders();
 
-const Split = () => {
+	return (
+		<SwapList swaps={openOrders} limit={swapLimit} showCancel/>
+	);
+};
+
+const CurrentPairOpenOrders = () => {
 	const {state} = exchangeContainer;
 
-	const filteredData = state.swapHistory.filter(x =>
-		x.baseCurrency === state.baseCurrency &&
-		x.quoteCurrency === state.quoteCurrency
+	const filteredData = getOpenOrders().filter(swap =>
+		swap.baseCurrency === state.baseCurrency &&
+		swap.quoteCurrency === state.quoteCurrency
 	);
 
 	return (
@@ -59,17 +65,17 @@ const Swaps = () => {
 				<nav>
 					<TabButton
 						title={t('swaps.all')}
-						component={All}
+						component={OpenOrders}
 					/>
 					<TabButton
 						title={`${state.baseCurrency}/${state.quoteCurrency}`}
-						component={Split}
+						component={CurrentPairOpenOrders}
 					/>
 				</nav>
 			</header>
 			<main>
-				<TabView component={All}/>
-				<TabView component={Split}/>
+				<TabView component={OpenOrders}/>
+				<TabView component={CurrentPairOpenOrders}/>
 			</main>
 		</div>
 	);


### PR DESCRIPTION
**Extends https://github.com/atomiclabs/hyperdex/pull/481. Just targeting the #481 branch for now so you can easily see what's changed in the diff/commits. If we decide to merge this it should be merged into master after #481.**

This PR changes the "Swaps" section of the Exchange view to "Open Orders". This is much more inline with how centralised excahnges work and makes more sense with GTC style orders. It's actually quite similar to the GDAX/Coinbase Pro UI so hopefully will seem more familiar to users.

Only open orders are listed in the exchange view. You can still filter the open orders down to the current trading pair. If you cancel them they will be removed from that view. One the order has been filled it will be removed from that view.

You can then view cancelled/completed orders in the Trades view.

Here an example of how it works:

![open orders demo](https://user-images.githubusercontent.com/2123375/44468963-5af47500-a61e-11e8-81b0-a85b1a868e1c.gif)

<sup>I make a reasonable CHIPS/KMD order and a super low MYTH/KMD order that will never match. These are the only orders listed, none of my previous orders are shown here, they are in the Trades view. I can filter down to trading pair to only view open orders in the current trading pair. The CHIPS order matches and starts swapping, the MYTH order remains unmatched. It will keep rebroadcasting every 10 minutes until it gets matched or until I cancel it. I then cancel it and it is removed from open orders. Once the CHIPS trade completes it will be removed from the "Open Orders" view (not shown in GIF)</sup>

I was really keen on implementing this but after testing it for a while I'm not 100% sure we should definitely merge it, there are a few caveats:

#### Cancel behaviour is buggy (https://github.com/atomiclabs/hyperdex/issues/262)

The cancel buttom seems to work inconsistently, I think this is due to the mm code only referencing one pending trade internall at a time in a global variable. Sometimes it seems to work ok but other times it doesn't.

#### Swap modal will disappear once order is complete

If you have the swap modal open while the order is going through, it will dissapear as soon as it's complete. This is because the swap list component is no longer rendered becasue it's no longer pending and the model component is a child compenent of that so it too stops rendering.

It's a bit confusing that you would be on `swap 4/5` and then modal suddenly dissapears. We could probably fix this be component heirachy around a bit so the modal can still be visible when the order list item dissapears.

#### Trades will sometimes randomly dissapear and come back due to mm bug (https://github.com/jl777/SuperNET/issues/956)

There is a bug in mm where we randomly get a failed/cancel event for a trade that hasn't failed/cancelled. Obvisouly we don't know the message is incorrect so we think the trade has failed and remove it from "Open Orders". Then, soon after we get another update from mm saying the swap progress has progressed and it will re-appear in "Open Orders" again.

This is pretty confusing because the order just dissapears and then re-appears. Also if the user has the swap modal open it will jsut close and the swap will be missing, only for it to re-appear after.

This will hopefully be fixed in mm soon (@jl777 is too busy on another project but I think @artemii235 may be taking a look into it). Even so, there is a hacky workaround we can implement that just ignore cancel events for trades that are in progress, as these should never be able to be cancelled.

I will implement a seperate PR for that and we can decide if we want to implement it.