### PR TITLE
Preserve "Cancel" button state in the swap list

### DIFF
--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -21,12 +21,9 @@ const SortDirections = {
 
 // eslint-disable-next-line no-unused-vars
 class CancelButton extends React.Component {
-	state = {
-		isCancelling: false,
-	}
-
 	cancelSwap = async swapUuid => {
-		this.setState({isCancelling: true});
+		await tradesContainer.setIsSwapCancelling(swapUuid, true);
+		this.forceUpdate();
 
 		try {
 			await appContainer.api.cancelOrder(swapUuid);
@@ -43,7 +40,10 @@ class CancelButton extends React.Component {
 			<button
 				type="button"
 				className="cancel__button"
-				disabled={swap.status !== 'pending' || this.state.isCancelling}
+				disabled={
+					swap.status !== 'pending' ||
+					tradesContainer.state.isSwapCancelling[swap.uuid]
+				}
 				onClick={() => this.cancelSwap(swap.uuid)}
 			>
 				{t('list.cancel')}

--- a/app/renderer/containers/Trades.js
+++ b/app/renderer/containers/Trades.js
@@ -3,10 +3,19 @@ import {Container} from 'unstated';
 class TradesContainer extends Container {
 	state = {
 		activeView: 'OpenOrders',
+		isSwapCancelling: {},
 	};
 
 	setActiveView = activeView => {
 		this.setState({activeView});
+	};
+
+	setIsSwapCancelling = (swapUuid, isCancelling) => {
+		this.setState(state => {
+			const {isSwapCancelling} = state;
+			isSwapCancelling[swapUuid] = isCancelling;
+			return state;
+		});
 	};
 }
 


### PR DESCRIPTION
We cannot keep local state as `react-virtualized` unmounts components outside the viewport:

> You might be aware of this, but just to be completely clear- **components will not retain state once they've left the viewport**. This is a limitation of windowing with react-virtualized (or similar libraries). Any "state" that should persist should be stored externally (eg within the underlying List/Array, in Redux, in the parent component's state, etc). - https://github.com/bvaughn/react-virtualized/issues/416#issuecomment-249381605