### PR TITLE
Use noun instead of a verb as activity title

### DIFF
--- a/app/locales/en-US/dashboard.json
+++ b/app/locales/en-US/dashboard.json
@@ -6,8 +6,7 @@
 	"activity": {
 		"noActivity": "No activity yet",
 		"recentActivity": "Recent Activity",
-		"swapFailedTitle": "Did Not Swap",
-		"swapTitle": "Swapped",
+		"swapTitle": "Trade",
 		"swapDescription": "{{quoteCurrency}} for {{baseCurrency}}"
 	},
 	"chart": {

--- a/app/renderer/views/Dashboard/WalletActivity.js
+++ b/app/renderer/views/Dashboard/WalletActivity.js
@@ -27,11 +27,7 @@ const ActivityItem = ({swap}) => {
 			</td>
 			<td className="type">
 				<div>
-					{/*
-						TODO: Use something more proper than `Did Not Swap`
-						https://github.com/atomiclabs/hyperdex/pull/160#discussion_r185178958
-					*/}
-					<div className="type-title">{swap.status === 'failed' ? t('activity.swapFailedTitle') : t('activity.swapTitle')}</div>
+					<div className="type-title">{t('activity.swapTitle')}</div>
 					<div className="type-description">
 						{t('activity.swapDescription', {
 							baseCurrency: swap.baseCurrency,


### PR DESCRIPTION
It looks better and makes it easier to add different activities. I also switched out Swap with Trade while I was at it.


<img width="616" alt="screen shot 2018-08-27 at 21 21 11" src="https://user-images.githubusercontent.com/170270/44665040-267a2200-aa3f-11e8-934d-e11ddeef265c.png">
