### PR TITLE
Use correct value to fix percentage change

### DIFF
--- a/app/renderer/containers/App.js
+++ b/app/renderer/containers/App.js
@@ -47,6 +47,7 @@ const getTickerData = async symbols => {
 		return {
 			symbol,
 			price: currency ? currency.current_price : 0,
+			percentChange24h: currency ? roundTo(Number(currency.price_change_percentage_24h), 1) : 0,
 		};
 	});
 


### PR DESCRIPTION
This was broken when we move to CoinGecko.

Will do a followup PR to remove all references to CMC and instead refer to prices as `fiatPrice` instead of `cmcPrice` etc.