### PR TITLE
Fetch swap history in `Dashboard`

### DIFF
--- a/app/renderer/containers/Dashboard.js
+++ b/app/renderer/containers/Dashboard.js
@@ -1,7 +1,8 @@
 import _ from 'lodash';
 import pMap from 'p-map';
-import {Container} from 'unstated';
 import appContainer from 'containers/App';
+import exchangeContainer from 'containers/Exchange';
+import SuperContainer from 'containers/SuperContainer';
 import {formatCurrency} from '../util';
 import {ignoreExternalPrice} from '../../constants';
 import {translate} from '../translate';
@@ -10,7 +11,7 @@ import fireEvery from '../fire-every';
 const t = translate('dashboard');
 const noPriceHistory = new Set();
 
-class DashboardContainer extends Container {
+class DashboardContainer extends SuperContainer {
 	state = {
 		activeView: 'Portfolio',
 		currencyHistoryResolution: 'month',
@@ -43,6 +44,10 @@ class DashboardContainer extends Container {
 
 			this.updateAllCurrencyHistory();
 		});
+	}
+
+	async componentDidInitialMount() {
+		await exchangeContainer.setSwapHistory();
 	}
 
 	setActiveView = async activeView => {

--- a/app/renderer/views/Dashboard/index.js
+++ b/app/renderer/views/Dashboard/index.js
@@ -41,4 +41,4 @@ const Dashboard = () => {
 	);
 };
 
-export default Dashboard;
+export default dashboardContainer.connect(Dashboard);


### PR DESCRIPTION
When logging in and viewing the recent activity on the dashboard, it'll show no activity since the trades aren't loaded yet. You have to go to the exchange or trades view for them to show up.

Ideally we would run the following code as soon as we're logged in https://github.com/atomiclabs/hyperdex/blob/master/app/renderer/containers/Exchange.js#L33-L46.