### PR TITLE
Fix Windows login issue

### DIFF
--- a/app/marketmaker/index.js
+++ b/app/marketmaker/index.js
@@ -8,6 +8,7 @@ const util = require('electron-util');
 const getPort = require('get-port');
 const logger = require('electron-timber');
 const makeDir = require('make-dir');
+const _ = require('lodash');
 const {supportedCurrencies} = require('./supported-currencies');
 
 // `electron-builder` uses different names
@@ -73,7 +74,9 @@ class Marketmaker {
 			gui: 'hyperdex',
 			userhome: os.homedir(),
 			rpcport: await getPort(),
-			coins: supportedCurrencies,
+			// We leave out `electrumServers` since it's not needed
+			// and to prevent issues on Windows with too long arguments
+			coins: supportedCurrencies.map(currency => _.omit(currency, ['electrumServers'])),
 		};
 
 		this.port = options.rpcport;


### PR DESCRIPTION
Windows seems to have a very low limit for the length of command arguments when spawning, so our recent currency additions made it go over that limit. A quick fix for now is to exclude the `electrumServers` property as it's not used by marketmaker. A proper longer-term fix would be for marketmaker to let us dynamically enable currencies with this info instead of having to supply it on startup.

Fixes #519
Fixes #525