### PR TITLE
Fix `Document update conflict` error

### DIFF
--- a/app/renderer/swap-db.js
+++ b/app/renderer/swap-db.js
@@ -1,5 +1,6 @@
 import PouchDB from 'pouchdb-browser';
 import pouchDBFind from 'pouchdb-find';
+import pouchDBUpsert from 'pouchdb-upsert';
 import cryptoPouch from 'crypto-pouch';
 import Emittery from 'emittery';
 import PQueue from 'p-queue';
@@ -13,6 +14,7 @@ import {translate} from './translate';
 const t = translate('swap');
 
 PouchDB.plugin(pouchDBFind);
+PouchDB.plugin(pouchDBUpsert);
 PouchDB.plugin(cryptoPouch);
 
 class SwapDB {
@@ -91,9 +93,11 @@ class SwapDB {
 	updateSwapData = message => {
 		return this.queue(async () => {
 			const swap = await this._getSwapData(message.uuid);
-			swap.messages.push(message);
 
-			return this.db.put(swap);
+			await this.db.upsert(swap._id, doc => {
+				doc.messages.push(message);
+				return doc;
+			});
 		});
 	}
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"p-queue": "^2.4.2",
 		"pouchdb-browser": "^7.0.0",
 		"pouchdb-find": "^7.0.0",
+		"pouchdb-upsert": "^2.2.0",
 		"prop-types": "^15.6.2",
 		"prop-types-range": "^0.0.0",
 		"qrcode.react": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7451,7 +7451,7 @@ pouchdb-promise@5.4.3:
   dependencies:
     lie "3.0.4"
 
-pouchdb-promise@^6.1.0:
+pouchdb-promise@^6.1.0, pouchdb-promise@^6.1.2:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-promise/-/pouchdb-promise-6.4.3.tgz#74516f4acf74957b54debd0fb2c0e5b5a68ca7b3"
   dependencies:
@@ -7463,6 +7463,12 @@ pouchdb-selector-core@7.0.0:
   dependencies:
     pouchdb-collate "7.0.0"
     pouchdb-utils "7.0.0"
+
+pouchdb-upsert@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-upsert/-/pouchdb-upsert-2.2.0.tgz#42b15e420848f3b294c35060589fdb51cf7f7f5f"
+  dependencies:
+    pouchdb-promise "^6.1.2"
 
 pouchdb-utils@7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Fixes #527
Fixes #528

We were not correctly updating the PouchDB documents. There is a required ceremony of updating `_rev` that we were not doing. I think the issue only first showed up now as IndexedDB either got faster or something changed internally with the Electron 3 upgrade.

See: https://pouchdb.com/guides/updating-deleting.html

I'm using `pouchdb-upsert` which handles some of the complications of updating a document.