### PR TITLE
Update Electrum servers for VIA, VTC, BTG

### DIFF
--- a/app/marketmaker/supported-currencies.js
+++ b/app/marketmaker/supported-currencies.js
@@ -338,16 +338,20 @@ const supportedCurrencies = [
 		txfee: 10000,
 		electrumServers: [
 			{
-				host: 'electrum1.cipig.net',
-				port: 10052,
+				host: 'electrumx-eu.bitcoingold.org',
+				port: 50001,
 			},
 			{
-				host: 'electrum2.cipig.net',
-				port: 10052,
+				host: 'electrumx-us.bitcoingold.org',
+				port: 50001,
 			},
 			{
-				host: 'electrum3.cipig.net',
-				port: 10052,
+				host: 'electrumx-eu.btcgpu.org',
+				port: 50001,
+			},
+			{
+				host: 'electrumx-us.btcgpu.org',
+				port: 50001,
 			},
 		],
 	},
@@ -2083,16 +2087,16 @@ const supportedCurrencies = [
 		txfee: 100000,
 		electrumServers: [
 			{
-				host: 'electrum1.cipig.net',
-				port: 10067,
+				host: 'viax1.bitops.me',
+				port: 50001,
 			},
 			{
-				host: 'electrum2.cipig.net',
-				port: 10067,
+				host: 'viax2.bitops.me',
+				port: 50001,
 			},
 			{
-				host: 'electrum3.cipig.net',
-				port: 10067,
+				host: 'viax3.bitops.me',
+				port: 50001,
 			},
 		],
 	},
@@ -2128,16 +2132,20 @@ const supportedCurrencies = [
 		txfee: 100000,
 		electrumServers: [
 			{
-				host: 'electrum1.cipig.net',
-				port: 10071,
+				host: 'fr1.vtconline.org',
+				port: 55001,
 			},
 			{
-				host: 'electrum2.cipig.net',
-				port: 10071,
+				host: 'uk1.vtconline.org',
+				port: 55001,
 			},
 			{
-				host: 'electrum3.cipig.net',
-				port: 10071,
+				host: 'vtc-cce-1.coinomi.net',
+				port: 5028,
+			},
+			{
+				host: 'vtc-cce-2.coinomi.net',
+				port: 5028,
 			},
 		],
 	},


### PR DESCRIPTION
From:
- https://github.com/jl777/coins/commit/53814405fe4956acf29c2978ef6d0de5f2670cc1#diff-4bf6cdadf06f67269b8f1e961d7be3b0
- https://github.com/jl777/coins/pull/167

Needs to be updated since @cipig plans to take down those Electrum servers.