### PR TITLE
Make the swap list rows clickable

### DIFF
--- a/app/renderer/components/SwapList.js
+++ b/app/renderer/components/SwapList.js
@@ -43,7 +43,10 @@ class CancelButton extends React.Component {
 					swap.status !== 'pending' ||
 					tradesContainer.state.isSwapCancelling[swap.uuid]
 				}
-				onClick={() => this.cancelSwap(swap.uuid)}
+				onClick={event => {
+					event.stopPropagation();
+					this.cancelSwap(swap.uuid);
+				}}
 			>
 				{t('list.cancel')}
 			</button>
@@ -83,7 +86,7 @@ const SwapHeader = props => (
 );
 
 const SwapItem = ({style, swap, showCancel, openSwap}) => (
-	<div className={`row ${swap.orderType}`} style={style}>
+	<div className={`row ${swap.orderType}`} style={style} onClick={openSwap}>
 		<div className="timestamp">{formatDate(swap.timeStarted, 'HH:mm DD/MM/YY')}</div>
 		<div className="pairs">{swap.baseCurrency}/{swap.quoteCurrency}</div>
 		<div className="base-amount">{swap.baseCurrencyAmount} {swap.baseCurrency}</div>
@@ -97,9 +100,6 @@ const SwapItem = ({style, swap, showCancel, openSwap}) => (
 					<CancelButton swap={swap}/>
 				</div>
 			)}
-			<div className="view">
-				<button type="button" className="view__button" onClick={openSwap}>{t('details.view')}</button>
-			</div>
 		</div>
 	</div>
 );

--- a/app/renderer/components/SwapList.scss
+++ b/app/renderer/components/SwapList.scss
@@ -133,8 +133,8 @@
 
 	@media (min-width: 1220px) {
 		.row {
-			grid-template-areas: 'timestamp pairs base-amount quote-amount status buttons';
-			grid-template-columns: 18% 0%;
+			grid-template-areas: 'timestamp base-amount quote-amount status buttons';
+			grid-template-columns: 0.8fr 1fr 1fr 0.5fr 0.5fr;
 			justify-content: unset;
 			white-space: unset;
 
@@ -151,7 +151,7 @@
 			}
 
 			.status {
-				justify-self: end;
+				justify-self: start;
 			}
 
 			.buttons {

--- a/app/renderer/components/SwapList.scss
+++ b/app/renderer/components/SwapList.scss
@@ -7,6 +7,7 @@
 	font-size: 12px;
 	height: 0;
 	min-height: 100%;
+	padding: 10px 0;
 
 	.container {
 		position: relative;
@@ -24,7 +25,9 @@
 		align-items: center;
 		white-space: nowrap;
 		border-bottom: 1px solid var(--section-border-color);
-		padding: 10px 0;
+		padding: 10px 20px;
+		user-select: none;
+		cursor: default;
 
 		&:last-child {
 			border-bottom: none;
@@ -66,6 +69,18 @@
 			> *:last-child {
 				margin-right: 0;
 			}
+
+			.cancel__button[disabled] {
+				transition: unset;
+			}
+		}
+	}
+
+	.row:not(.header):hover {
+		background-color: var(--table-row-hover-color);
+
+		.cancel__button[disabled] {
+			opacity: 0.7;
 		}
 	}
 
@@ -116,10 +131,10 @@
 		}
 	}
 
-	@media (min-width: 1280px) {
+	@media (min-width: 1220px) {
 		.row {
 			grid-template-areas: 'timestamp pairs base-amount quote-amount status buttons';
-			grid-template-columns: 14% 0% 23% 23%;
+			grid-template-columns: 18% 0%;
 			justify-content: unset;
 			white-space: unset;
 

--- a/app/renderer/styles/variables.scss
+++ b/app/renderer/styles/variables.scss
@@ -44,6 +44,7 @@
 	--depth-chart-sell-background-color: #5a2947;
 	--depth-chart-sell-stroke-color: #f80759;
 	--order-list-item-hover: rgba(255, 255, 255, 0.05);
+	--table-row-hover-color: hsla(216, 27%, 24%, 1);
 }
 
 html[data-theme='light'] {
@@ -75,6 +76,7 @@ html[data-theme='light'] {
 	--depth-chart-sell-background-color: #f6e1ed;
 	--depth-chart-sell-stroke-color: #f53f78;
 	--order-list-item-hover: rgba(0, 0, 0, 0.05);
+	--table-row-hover-color: hsla(0, 0%, 91%, 1);
 }
 
 @mixin icon-button {

--- a/app/renderer/views/Exchange/Swaps.scss
+++ b/app/renderer/views/Exchange/Swaps.scss
@@ -24,7 +24,6 @@
 	main {
 		display: flex;
 		flex: 1;
-		padding: 10px 20px;
 	}
 
 	.history-button {

--- a/app/renderer/views/Trades.scss
+++ b/app/renderer/views/Trades.scss
@@ -32,7 +32,7 @@
 	main {
 		.SwapList {
 			.row {
-				padding: 12px 5px 12px 0;
+				padding: 12px 25px 12px 20px;
 				font-size: 14px;
 			}
 


### PR DESCRIPTION
Instead of using the tiny "View" button. There is now a hover effect to make it clear that it's clickable. This is generally how it works natively and after using it for a few days, I feel it's better.

<img width="1346" alt="screen shot 2018-10-18 at 23 33 26" src="https://user-images.githubusercontent.com/170270/47169921-f2c8c380-d32e-11e8-92b8-0edae08298d0.png">

The "Cancel" button is still clickable.