### PR TITLE
Add more logging

### DIFF
--- a/app/marketmaker/index.js
+++ b/app/marketmaker/index.js
@@ -93,6 +93,9 @@ class Marketmaker {
 		// Marketmaker writes a lot of files directly to CWD, so we make CWD the data directory
 		const cwd = await makeDir(path.join(electron.app.getPath('userData'), 'marketmaker'));
 
+		// Uncomment this to get the command to run Marketmaker manually
+		// logger.log(`Run Marketmaker manually:\n'${binPath}' '${JSON.stringify(options)}'`);
+
 		this.cp = childProcess.spawn(binPath, [JSON.stringify(options)], {cwd});
 
 		this.cp.on('error', error => {


### PR DESCRIPTION
And refactor the `request` method.

This will give us a nice overview of what HyperDEX is doing regarding communication with Marketmaker and even how long it takes. I initially needed this for #563, but it's useful for mm v1 too.

By combining `_request` and `request`, I managed simplify it. I also had to do this to get access to the data I needed at the same time for logging.

It shows both the request and the response:

<img width="801" alt="screen shot 2018-11-01 at 23 57 45" src="https://user-images.githubusercontent.com/170270/47867296-b2d80500-de33-11e8-8d10-922937e392e0.png">
