### PR TITLE
Stop filtering order books based on UTXO count

### DIFF
--- a/app/renderer/api.js
+++ b/app/renderer/api.js
@@ -173,12 +173,10 @@ export default class Api {
 		});
 
 		const formatOrders = orders => orders
-			.filter(order => order.numutxos > 0)
 			.map(order => ({
 				address: order.address,
 				depth: order.depth,
 				price: order.price,
-				utxoCount: order.numutxos,
 				averageVolume: order.avevolume,
 				maxVolume: order.maxvolume,
 				zCredits: order.zcredits,


### PR DESCRIPTION
Since it's going away in mm v2 and it's not that useful or accurate anyway.

I'm trying to land as many changes on master as possible so we don't diverge too much, since I expect the mm v2 branch to be long-running.